### PR TITLE
Fixed error when using damage_type enum in TakeDamageInfo

### DIFF
--- a/addons/source-python/packages/source-python/entities/constants.py
+++ b/addons/source-python/packages/source-python/entities/constants.py
@@ -7,7 +7,7 @@
 # =============================================================================
 # Python Imports
 #   Enum
-from enum import Enum
+from enum import IntEnum
 
 # Site-Package Imports
 #   ConfigObj
@@ -45,4 +45,4 @@ DATA_DESC_MAP_OFFSET = _entity_values.get(
     'DATA_DESC_OFFSET', {}).get(PLATFORM, None)
 
 # Get the damage_types for the current engine
-damage_types = Enum('damage_types', _entity_values.get('damage_types', {}))
+damage_types = IntEnum('damage_types', _entity_values.get('damage_types', {}))


### PR DESCRIPTION
The usage of entities.constants.damage_types to define damage type in TakeDamageInfo object cause boost exception:
```
Boost.Python.ArgumentError: Python argument types in
    None.None(TakeDamageInfo, damage_types)
did not match C++ signature:
    None(class CTakeDamageInfo {lvalue}, int)
```

Code:
```python
from basetypes import TakeDamageInfo
from entities.constants import damage_types

take_damage_info = TakeDamageInfo()
take_damage_info.type = damage_types.GENERIC
```