### PR TITLE
Fixed server crash when precaching on server startup

### DIFF
--- a/addons/source-python/packages/source-python/engines/precache.py
+++ b/addons/source-python/packages/source-python/engines/precache.py
@@ -19,12 +19,11 @@ from path import Path
 # Source.Python Imports
 #   Core
 from core import AutoUnload
+from core import global_vars
 #   Engines
 from engines.server import engine_server
 #   Events
 from events.manager import event_registry
-#   Listeners
-from listeners.tick.delays import tick_delays
 #   Stringtables
 from stringtables import INVALID_STRING_INDEX
 from stringtables import string_tables
@@ -67,8 +66,10 @@ class _PrecacheBase(Path, AutoUnload):
         # Set the _calling_module attribute for the instance
         self._calling_module = caller.__name__
 
-        # Precache the instance
-        tick_delays.delay(0.0, self._precache_method, self)
+        # Is the map loaded?
+        if global_vars.map_name:
+            # Precache the instance
+            self._precache_method(self)
 
         # Register the server_spawn event to precache every map change
         event_registry.register_for_event('server_spawn', self._server_spawn)

--- a/addons/source-python/packages/source-python/engines/precache.py
+++ b/addons/source-python/packages/source-python/engines/precache.py
@@ -23,6 +23,8 @@ from core import AutoUnload
 from engines.server import engine_server
 #   Events
 from events.manager import event_registry
+#   Listeners
+from listeners.tick.delays import tick_delays
 #   Stringtables
 from stringtables import INVALID_STRING_INDEX
 from stringtables import string_tables
@@ -66,7 +68,7 @@ class _PrecacheBase(Path, AutoUnload):
         self._calling_module = caller.__name__
 
         # Precache the instance
-        self._precache_method(self)
+        tick_delays.delay(0.0, self._precache_method, self)
 
         # Register the server_spawn event to precache every map change
         event_registry.register_for_event('server_spawn', self._server_spawn)


### PR DESCRIPTION
Server crashes if engines.precache.Model object is being created on server load.

For example, I have simple plugin:
```python
from engines.precache import Model

test_model = Model('models/player/t_leet.mdl')
```
which is loaded through autoexec.cfg. When I start the server it crashes with this error:
```
Host_Error: CVEngineServer::PrecacheModel: 'models/player/t_leet.mdl' overflow, too many models
```

I don't know if there is the same problem with Decal and Generic class, but this fix will work for them too :smiley: 

Tested on CS:S, Linux (custom build from Jan 15)/Windows (official Jan 15 build).