### PR TITLE
Fixed crash caused by ServerCommand registration without Help text.

### DIFF
--- a/src/core/modules/commands/server_commands_wrap.cpp
+++ b/src/core/modules/commands/server_commands_wrap.cpp
@@ -128,7 +128,7 @@ CServerCommandManager* CServerCommandManager::CreateCommand(const char* szName,
 		// Unregister the old command
 		g_pCVar->UnregisterConCommand(pConCommand);
 	}
-	else
+	else if( szHelpText != NULL )
 	{
 		// Store the given help text
 		szHelpTextCopy = strdup(szHelpText);


### PR DESCRIPTION
When I register ServerCommand without help text in arguments my Linux CS:S server crashes.
```python
from commands.server import ServerCommand

# No Help text
@ServerCommand('test_me')
def test_me_command(command):
    print("It works!")
```
This one works fine:
```python
@ServerCommand('test_me', 'Help text!')
```
Same problem when using `server_command_manager.register_commands` directly.

The segfault was caused by passing `NULL` to `strdup`.

Windows doesn't have this problem and I haven't tested how this fix works on Windows server, but everything should be fine... I think... ~~Any way I don't have Visual Studio installed.~~