### PR TITLE
Fix usermessages not being sent when player classname is changed.

### DIFF
--- a/src/core/modules/filters/filters_recipients.cpp
+++ b/src/core/modules/filters/filters_recipients.cpp
@@ -109,13 +109,6 @@ void MRecipientFilter::AddAllPlayers()
 			continue;
 		}
 
-		// Get and compare the classnames. Skip non-player
-		// entities.
-		const char* classname = pPlayer->GetClassName();
-		if( strcmp(classname, "player") != 0 ) {
-			continue;
-		}
-
 		m_Recipients.AddToTail(i);
 	}
 }
@@ -130,14 +123,9 @@ void MRecipientFilter::AddRecipient(int iPlayer)
 	if(!pPlayer)
 		return;
 
-	// Get and compare the classnames. Skip non-player
-	// entities.
-	const char* classname = pPlayer->GetClassName();
-	if( strcmp(classname, "player") != 0 ) {
-		return;
-	}
-
-	m_Recipients.AddToTail(iPlayer);
+	// Skip non-player entities.
+	if (iPlayer > WORLD_ENTITY_INDEX && iPlayer <= gpGlobals->maxClients)
+		m_Recipients.AddToTail(iPlayer);
 }
 
 void MRecipientFilter::RemoveRecipient( int iPlayer )


### PR DESCRIPTION
It is possible to set the classname keyvalue of a player entity to something other than "player". Some custom maps make use of this in conjunction with filter_activator_class for various things.