### PR TITLE
Added 'event_name' to event's kwargs

### DIFF
--- a/addons/source-python/packages/source-python/events/hooks.py
+++ b/addons/source-python/packages/source-python/events/hooks.py
@@ -183,6 +183,7 @@ def _pre_game_event(args):
     # TODO: use data or some other means to get the offset
     kwargs = make_object(
         KeyValues, get_object_pointer(game_event).get_pointer(8)).as_dict()
+    kwargs['event_name'] = event_name
 
     # Loop through all callbacks in the pre-event's list
     for callback in pre_event_manager[event_name]:

--- a/addons/source-python/packages/source-python/events/listener.py
+++ b/addons/source-python/packages/source-python/events/listener.py
@@ -91,6 +91,7 @@ class _EventListener(list):
         # TODO: use data or some other means to get the offset
         kwargs = make_object(
             KeyValues, get_object_pointer(game_event).get_pointer(8)).as_dict()
+        kwargs['event_name'] = game_event.get_name()
 
         # Loop through each callback in the event's list
         for callback in self:


### PR DESCRIPTION
Event's name is still required when registering the same callback for multiple events:

    @Event('player_spawn', 'player_jump')
    def on_event(**eargs):
        print('Player with userid of {userid} triggered {event_name}.'.format(**eargs))

I chose to use `'event_name'` since it can still be grabbed in the parameters (`'event name'` could not be):

    @Event('player_spawn')
    def on_spawn(event_name, **eargs):
        pass

And simply using `'name'` felt a little ambiguous.