### PR TITLE
Return the original callback from commands' __call__

### DIFF
--- a/addons/source-python/packages/source-python/commands/command.py
+++ b/addons/source-python/packages/source-python/commands/command.py
@@ -25,11 +25,8 @@ class _BaseCommand(AutoUnload):
 
     def __call__(self, callback):
         """Register the commands to the given callback."""
-        if isinstance(callback, _BaseCommand):
-            # Always register the actual callback and not a previous decorator
-            self.callback = callback.callback
-        else:
-            self.callback = callback
+        # Store the callback
+        self.callback = callback
 
         # Register the commands
         self._manager_class.register_commands(

--- a/addons/source-python/packages/source-python/commands/command.py
+++ b/addons/source-python/packages/source-python/commands/command.py
@@ -32,8 +32,8 @@ class _BaseCommand(AutoUnload):
         self._manager_class.register_commands(
             self.names, self.callback, *self.args, **self.kwargs)
 
-        # Return the object
-        return self
+        # Return the original callback
+        return callback
 
     def _unload_instance(self):
         """Unregister the commands."""


### PR DESCRIPTION
Before if you did this:

    @ClientCommand('test')
    @SayCommand('test')
    def test(*args):
        print('test() was called')

It would raise an error because `_BaseCommand.__call__()` returns the command instance itself, as opposed to the original `test` function. This would cause `SayCommand` to attempt to register the `ClientCommand` instance as a callback, which would fail.

@Ayuto already hotfixed this [here](https://github.com/Source-Python-Dev-Team/Source.Python/commit/f1a00610cd3c17d6d440f50413707209026819c1), but I believe that's just a workaround and doesn't solve the actual issue: the decorator is returned instead of the decorated function. Also, his workaround still doesn't allow one to call the `test()` function after decorating it as a command. The following code wouldn't work because `test` is now a `ClientCommand` instance:

    @ClientCommand('test')
    def test(*args):
        print('test() was called')

    test()

Returning the command instance was necessary with the old `AutoUnload` class which operated on global variables based on their name, but [this](https://github.com/Source-Python-Dev-Team/Source.Python/commit/7984c06b7ad5310033b67cbf83e181f90240a3b8) update greatly improved the mechanism and returning the object is no longer required.