### PR TITLE
Kwargs and return values to filters and hooks' __call__

### DIFF
--- a/addons/source-python/packages/source-python/commands/filter.py
+++ b/addons/source-python/packages/source-python/commands/filter.py
@@ -31,9 +31,9 @@ class _BaseFilter(AutoUnload):
         # Register the filter
         self._manager_class.register_filter(self.callback)
 
-    def __call__(self, *args):
+    def __call__(self, *args, **kwargs):
         """Call the callback."""
-        self.callback(*args)
+        return self.callback(*args, **kwargs)
 
     def _unload_instance(self):
         """Unregister the filter."""

--- a/addons/source-python/packages/source-python/hooks/base.py
+++ b/addons/source-python/packages/source-python/hooks/base.py
@@ -83,9 +83,9 @@ class _HookDecorator(AutoUnload):
         self.callback = callback
         self._class_instance.append(self.callback)
 
-    def __call__(self, *args):
+    def __call__(self, *args, **kwargs):
         """Call the callback."""
-        self.callback(*args)
+        return self.callback(*args, **kwargs)
 
     def _unload_instance(self):
         """Unregister the hook."""


### PR DESCRIPTION
Should be quite self-explanatory. Even if they're not currently used by anything, this improves extendability and if someone wants to use kwargs or the return value, let them.