### PR TITLE
Added from_userid() for PlayerDictionary

### DIFF
--- a/addons/source-python/packages/source-python/players/dictionary.py
+++ b/addons/source-python/packages/source-python/players/dictionary.py
@@ -10,6 +10,7 @@
 from entities.dictionary import EntityDictionary
 #   Players
 from players.entity import Player
+from players.helpers import index_from_userid
 
 
 # =============================================================================
@@ -28,3 +29,11 @@ class PlayerDictionary(EntityDictionary):
     def __init__(self, player_class=Player):
         """Initialize the dictionary."""
         super().__init__(player_class)
+
+    def from_userid(self, userid):
+        """Get a player instance from a userid.
+        
+        :param int userid: The userid.
+        :rtype: Player
+        """
+        return self[index_from_userid(userid)]


### PR DESCRIPTION
Since the `Player` entity class [got a `from_userid()`](https://github.com/Source-Python-Dev-Team/Source.Python/commit/8a45c575b95e8fcba8fc419e0a02f6c8bfdc0cba), I think `PlayerDictionary` should have one too for consistency and easier usage in events.