### PR TITLE
Weapon Data: Fix CS:GO clip & maxammo values for negev, hkp2000 and tec9

### DIFF
--- a/addons/source-python/data/source-python/weapons/csgo.ini
+++ b/addons/source-python/data/source-python/weapons/csgo.ini
@@ -237,7 +237,7 @@
 
     [[negev]]
         slot = 1
-        maxammo = 200
+        maxammo = 300
         ammoprop = 5
         clip = 150
         cost = 5700
@@ -295,9 +295,9 @@
 
     [[hkp2000]]
         slot = 2
-        maxammo = 24
+        maxammo = 52
         ammoprop = 10
-        clip = 12
+        clip = 13
         cost = 200
         item_definition_index = 32
         tags = "all,secondary,pistol"
@@ -323,9 +323,9 @@
 
     [[tec9]]
         slot = 2
-        maxammo = 120
+        maxammo = 90
         ammoprop = 7
-        clip = 32
+        clip = 18
         cost = 500
         item_definition_index = 30
         tags = "all,secondary,pistol"


### PR DESCRIPTION
During testing of my plugin, I figured out that there is an inconsistency between the INI file and the actual values for said weapons. The recent weapon updates for CS:GO might have been the reason for that.