### PR TITLE
Menus: Add register_close_callback decorator

### DIFF
--- a/addons/source-python/packages/source-python/menus/base.py
+++ b/addons/source-python/packages/source-python/menus/base.py
@@ -41,7 +41,7 @@ class _BaseMenu(AutoUnload, list):
 
     _instances = {}
 
-    def __init__(self, data=None, select_callback=None, build_callback=None):
+    def __init__(self, data=None, select_callback=None, build_callback=None, close_callback=None):
         """Initialize the menu.
 
         :param iterable|None data: Data that should be added to the menu.
@@ -59,11 +59,19 @@ class _BaseMenu(AutoUnload, list):
             The callback will receive 2 parameters:
                 1. The instance of this menu.
                 2. The index of the player who will receive this menu.
+
+        :param callable|None close_callback: A function that gets called
+            when a menu is closed by a player.
+
+            The callback will receive 2 parameters:
+                1. The instance of this menu.
+                2. The index of the player who will close this menu.
         """
         super().__init__(list() if data is None else data)
 
         self.select_callback = select_callback
         self.build_callback = build_callback
+        self.close_callback = close_callback
         self._player_pages = defaultdict(_PlayerPage)
         self._instances[id(self)] = self
 
@@ -112,6 +120,15 @@ class _BaseMenu(AutoUnload, list):
         """
         if self.select_callback is not None:
             return self.select_callback(self, player_index, choice_index)
+
+    def _select_close(self, player_index):
+        """Handle the close menu selection.
+
+        :param int player_index: The index of the player who made the
+            selection.
+        """
+        if self.close_callback is not None:
+            return self.close_callback(self, player_index)
 
     def send(self, *ply_indexes, **tokens):
         """Send the menu to the given player indexes.
@@ -258,6 +275,21 @@ class _BaseMenu(AutoUnload, list):
                 2. The index of the player who will receive this menu.
         """
         self.build_callback = callback
+        return callback
+
+    def register_close_callback(self, callback):
+        """Register a close callback for the menu.
+
+        Can and should be used as a decorator.
+
+        :param callable callback: A function that gets called
+            when a menu is closed by a player.
+
+            The callback will receive 2 parameters:
+                1. The instance of this menu.
+                2. The index of the player who will receive this menu.
+        """
+        self.close_callback = callback
         return callback
 
 

--- a/addons/source-python/packages/source-python/menus/esc.py
+++ b/addons/source-python/packages/source-python/menus/esc.py
@@ -49,7 +49,7 @@ class SimpleESCMenu(_BaseMenu):
     """This class creates basic ESC menus."""
 
     def __init__(
-            self, data=None, select_callback=None, build_callback=None,
+            self, data=None, select_callback=None, build_callback=None, close_callback=None,
             description=None, title=None, title_color=WHITE):
         """Initialize the object.
 
@@ -58,13 +58,15 @@ class SimpleESCMenu(_BaseMenu):
             :meth:`menus.base._BaseMenu.__init__`.
         :param callable|None build_callback: See
             :meth:`menus.base._BaseMenu.__init__`.
+        :param callable|None close_callback: See
+            :meth:`menus.base._BaseMenu.__init__`
         :param str|None description: A description that is displayed under the
             title.
         :param str|None title: A title that is displayed at the top of the
             menu.
         :param Color title_color: The color of the title.
         """
-        super().__init__(data, select_callback, build_callback)
+        super().__init__(data, select_callback, build_callback, close_callback)
         self.description = description
         self.title = title
         self.title_color = title_color
@@ -109,7 +111,7 @@ class SimpleESCMenu(_BaseMenu):
     def _select(self, player_index, choice_index):
         """See :meth:`menus.base._BaseMenu._select`."""
         if choice_index == 0:
-            return None
+            return self._select_close(player_index)
 
         option = self._player_pages[player_index].options[choice_index]
         if not option.selectable:
@@ -165,7 +167,7 @@ class PagedESCMenu(SimpleESCMenu, _PagedMenuBase):
     """
 
     def __init__(
-            self, data=None, select_callback=None, build_callback=None,
+            self, data=None, select_callback=None, build_callback=None, close_callback=None,
             description=None, title=None, title_color=WHITE, fill=True,
             parent_menu=None):
         """Initialize the object.
@@ -174,6 +176,8 @@ class PagedESCMenu(SimpleESCMenu, _PagedMenuBase):
         :param callable|None select_callback: See
             :meth:`menus.base._BaseMenu.__init__`.
         :param callable|None build_callback: See
+            :meth:`menus.base._BaseMenu.__init__`.
+        :param callable|None close_callback: See
             :meth:`menus.base._BaseMenu.__init__`.
         :param str|None description: See :meth:`SimpleESCMenu.__init__`.
         :param str|None title: See :meth:`SimpleESCMenu.__init__`.
@@ -184,7 +188,7 @@ class PagedESCMenu(SimpleESCMenu, _PagedMenuBase):
             hitting 'Back' on the first page.
         """
         super().__init__(
-            data, select_callback, build_callback,
+            data, select_callback, build_callback, close_callback,
             description, title, title_color)
         self.fill = fill
         self.parent_menu = parent_menu
@@ -280,10 +284,9 @@ class PagedESCMenu(SimpleESCMenu, _PagedMenuBase):
 
     def _select(self, player_index, choice_index):
         """See :meth:`menus.base._BaseMenu._select`."""
-        # Do nothing if the menu is being closed
         if choice_index == 0:
             del self._player_pages[player_index]
-            return None
+            return self._select_close(player_index)
 
         # Get the player's current page
         page_index = self.get_player_page(player_index)
@@ -311,7 +314,7 @@ class ListESCMenu(PagedESCMenu):
     Navigation options are added automatically."""
 
     def __init__(
-            self, data=None, select_callback=None, build_callback=None,
+            self, data=None, select_callback=None, build_callback=None, close_callback=None,
             description=None, title=None, title_color=WHITE, fill=True,
             parent_menu=None, items_per_page=5):
         """Initialize the object.
@@ -321,6 +324,8 @@ class ListESCMenu(PagedESCMenu):
             :meth:`menus.base._BaseMenu.__init__`.
         :param callable|None build_callback: See
             :meth:`menus.base._BaseMenu.__init__`.
+        :param callable|None close_callback: See
+            :meth:`menus.base._BaseMenu.__init__`.
         :param str|None description: See :meth:`SimpleESCMenu.__init__`.
         :param str|None title: See :meth:`SimpleESCMenu.__init__`.
         :param Color title_color: See :meth:`SimpleESCMenu.__init__`.
@@ -329,7 +334,7 @@ class ListESCMenu(PagedESCMenu):
         :param int items_per_page: Number of options that should be displayed
             on a single page (5 is the maximum).
         """
-        super().__init__(data, select_callback, build_callback, description,
+        super().__init__(data, select_callback, build_callback, close_callback, description,
             title, title_color, fill, parent_menu)
         self.items_per_page = items_per_page
 

--- a/addons/source-python/packages/source-python/menus/radio.py
+++ b/addons/source-python/packages/source-python/menus/radio.py
@@ -106,7 +106,7 @@ class SimpleRadioMenu(_BaseMenu):
     def _select(self, player_index, choice_index):
         """See :meth:`menus.base._BaseMenu._select`."""
         if choice_index == BUTTON_CLOSE:
-            return None
+            return self._select_close(player_index)
 
         return super()._select(
             player_index,
@@ -139,7 +139,7 @@ class PagedRadioMenu(SimpleRadioMenu, _PagedMenuBase):
 
     def __init__(
             self, data=None, select_callback=None,
-            build_callback=None, description=None,
+            build_callback=None, close_callback=None, description=None,
             title=None, top_separator='-' * 30, bottom_separator='-' * 30,
             fill=True, parent_menu=None):
         """Initialize the object.
@@ -148,6 +148,8 @@ class PagedRadioMenu(SimpleRadioMenu, _PagedMenuBase):
         :param callable|None select_callback: See
             :meth:`menus.base._BaseMenu.__init__`.
         :param callable|None build_callback: See
+            :meth:`menus.base._BaseMenu.__init__`.
+        :param callable|None close_callback: See
             :meth:`menus.base._BaseMenu.__init__`.
         :param str|None description: A description that is displayed under the
             title.
@@ -162,7 +164,7 @@ class PagedRadioMenu(SimpleRadioMenu, _PagedMenuBase):
         :param _BaseMenu parent_menu: A menu that will be displayed when
             hitting 'Back' on the first page.
         """
-        super().__init__(data, select_callback, build_callback)
+        super().__init__(data, select_callback, build_callback, close_callback)
 
         self.title = title
         self.description = description
@@ -290,10 +292,9 @@ class PagedRadioMenu(SimpleRadioMenu, _PagedMenuBase):
 
     def _select(self, player_index, choice_index):
         """See :meth:`menus.base._BaseMenu._select`."""
-        # Do nothing if the menu is being closed
         if choice_index == BUTTON_CLOSE:
             del self._player_pages[player_index]
-            return None
+            return self._select_close(player_index)
 
         # Get the player's current page
         page = self._player_pages[player_index]
@@ -321,7 +322,7 @@ class ListRadioMenu(PagedRadioMenu):
     Navigation options are added automatically."""
 
     def __init__(
-            self, data=None, select_callback=None, build_callback=None,
+            self, data=None, select_callback=None, build_callback=None, close_callback=None,
             description=None, title=None, top_separator='-' * 30,
             bottom_separator='-' * 30, fill=True, parent_menu=None,
             items_per_page=10):
@@ -332,6 +333,8 @@ class ListRadioMenu(PagedRadioMenu):
             :meth:`menus.base._BaseMenu.__init__`.
         :param callable|None build_callback: See
             :meth:`menus.base._BaseMenu.__init__`.
+        :param callable|None close_callback: See
+            :meth:`menus.base._BaseMenu.__init__`.
         :param str|None description: See :meth:`PagedRadioMenu.__init__`.
         :param str|None title: See :meth:`PagedRadioMenu.__init__`.
         :param str top_separator: See :meth:`PagedRadioMenu.__init__`.
@@ -341,7 +344,7 @@ class ListRadioMenu(PagedRadioMenu):
         :param int items_per_page: Number of options that should be displayed
             on a single page.
         """
-        super().__init__(data, select_callback, build_callback, description,
+        super().__init__(data, select_callback, build_callback, close_callback, description,
             title, top_separator, bottom_separator, fill, parent_menu)
         self.items_per_page = items_per_page
 


### PR DESCRIPTION
Simple usage example:
```python
from menus import PagedMenu
from menus import PagedOption
from players.entity import Player

main_menu = PagedMenu(
    [
        PagedOption('Say Hi', 0),
        PagedOption('Say something else', 1)
    ], title='Main Menu'
)


@main_menu.register_select_callback
def main_menu_select(menu, index, option):
    print(option.text)

@main_menu.register_close_callback
def main_menu_closed(menu, index):
    player = Player(index)
    print(f'Player {player.name} closed {menu.title}')
```

If you have any change requests, post them here :)