### PR TITLE
Fixed commands not registering properly when given strings are not persistent

### DIFF
--- a/src/core/modules/commands/commands_client.cpp
+++ b/src/core/modules/commands/commands_client.cpp
@@ -153,7 +153,7 @@ PLUGIN_RESULT DispatchClientCommand(edict_t* pEntity, const CCommand &command)
 //-----------------------------------------------------------------------------
 CClientCommandManager::CClientCommandManager(const char* szName)
 {
-	m_Name = szName;
+	m_Name = strdup(szName);
 }
 
 //-----------------------------------------------------------------------------
@@ -161,6 +161,7 @@ CClientCommandManager::CClientCommandManager(const char* szName)
 //-----------------------------------------------------------------------------
 CClientCommandManager::~CClientCommandManager()
 {
+	free(m_Name);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/core/modules/commands/commands_client.cpp
+++ b/src/core/modules/commands/commands_client.cpp
@@ -68,7 +68,7 @@ CClientCommandManager* GetClientCommand(const char* szName)
 	if (!find_manager<ClientCommandMap, ClientCommandMap::iterator>(g_ClientCommandMap, szName, iter))
 	{
 		manager = new CClientCommandManager(szName);
-		g_ClientCommandMap.insert(std::make_pair(szName, manager));
+		g_ClientCommandMap.insert(std::make_pair(manager->m_Name, manager));
 	}
 	else
 	{

--- a/src/core/modules/commands/commands_client.cpp
+++ b/src/core/modules/commands/commands_client.cpp
@@ -161,7 +161,7 @@ CClientCommandManager::CClientCommandManager(const char* szName)
 //-----------------------------------------------------------------------------
 CClientCommandManager::~CClientCommandManager()
 {
-	free(m_Name);
+	free((char*)m_Name);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/core/modules/commands/commands_say.cpp
+++ b/src/core/modules/commands/commands_say.cpp
@@ -296,7 +296,7 @@ CSayCommandManager::CSayCommandManager(const char* szName)
 //-----------------------------------------------------------------------------
 CSayCommandManager::~CSayCommandManager()
 {
-	free(m_Name);
+	free((char*)m_Name);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/core/modules/commands/commands_say.cpp
+++ b/src/core/modules/commands/commands_say.cpp
@@ -99,11 +99,10 @@ CSayCommandManager* GetSayCommand(const char* szName)
 {
 	CSayCommandManager* manager = NULL;
 	SayCommandMap::iterator iter;
-	char* szNameCopy = strdup(szName);
-	if (!find_manager<SayCommandMap, SayCommandMap::iterator>(g_SayCommandMap, szNameCopy, iter))
+	if (!find_manager<SayCommandMap, SayCommandMap::iterator>(g_SayCommandMap, szName, iter))
 	{
-		manager = new CSayCommandManager(szNameCopy);
-		g_SayCommandMap.insert(std::make_pair(szNameCopy, manager));
+		manager = new CSayCommandManager(szName);
+		g_SayCommandMap.insert(std::make_pair(szName, manager));
 	}
 	else
 	{
@@ -289,7 +288,7 @@ void SayConCommand::Dispatch( const CCommand& command )
 //-----------------------------------------------------------------------------
 CSayCommandManager::CSayCommandManager(const char* szName)
 {
-	m_Name = szName;
+	m_Name = strdup(szName);
 }
 
 //-----------------------------------------------------------------------------
@@ -297,6 +296,7 @@ CSayCommandManager::CSayCommandManager(const char* szName)
 //-----------------------------------------------------------------------------
 CSayCommandManager::~CSayCommandManager()
 {
+	free(m_Name);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/core/modules/commands/commands_say.cpp
+++ b/src/core/modules/commands/commands_say.cpp
@@ -99,10 +99,11 @@ CSayCommandManager* GetSayCommand(const char* szName)
 {
 	CSayCommandManager* manager = NULL;
 	SayCommandMap::iterator iter;
-	if (!find_manager<SayCommandMap, SayCommandMap::iterator>(g_SayCommandMap, szName, iter))
+	char* szNameCopy = strdup(szName);
+	if (!find_manager<SayCommandMap, SayCommandMap::iterator>(g_SayCommandMap, szNameCopy, iter))
 	{
-		manager = new CSayCommandManager(szName);
-		g_SayCommandMap.insert(std::make_pair(szName, manager));
+		manager = new CSayCommandManager(szNameCopy);
+		g_SayCommandMap.insert(std::make_pair(szNameCopy, manager));
 	}
 	else
 	{

--- a/src/core/modules/commands/commands_say.cpp
+++ b/src/core/modules/commands/commands_say.cpp
@@ -102,7 +102,7 @@ CSayCommandManager* GetSayCommand(const char* szName)
 	if (!find_manager<SayCommandMap, SayCommandMap::iterator>(g_SayCommandMap, szName, iter))
 	{
 		manager = new CSayCommandManager(szName);
-		g_SayCommandMap.insert(std::make_pair(szName, manager));
+		g_SayCommandMap.insert(std::make_pair(manager->m_Name, manager));
 	}
 	else
 	{

--- a/src/core/modules/commands/commands_server.cpp
+++ b/src/core/modules/commands/commands_server.cpp
@@ -169,7 +169,7 @@ CServerCommandManager::~CServerCommandManager()
 		g_pCVar->RegisterConCommand(m_pOldCommand);
 	}
 
-	free(m_Name);
+	free((char*)m_Name);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/core/modules/commands/commands_server.cpp
+++ b/src/core/modules/commands/commands_server.cpp
@@ -87,7 +87,7 @@ CServerCommandManager* GetServerCommand(const char* szName,
 	if (!find_manager<ServerCommandMap, ServerCommandMap::iterator>(g_ServerCommandMap, szName, iter))
 	{
 		manager = CServerCommandManager::CreateCommand(szName, szHelpText, iFlags);
-		g_ServerCommandMap.insert(std::make_pair(szName, manager));
+		g_ServerCommandMap.insert(std::make_pair(manager->m_Name, manager));
 	}
 	else
 	{

--- a/src/core/modules/commands/commands_server.cpp
+++ b/src/core/modules/commands/commands_server.cpp
@@ -148,7 +148,7 @@ CServerCommandManager::CServerCommandManager(ConCommand* pConCommand,
 	ConCommand(szName, (FnCommandCallback_t)NULL, szHelpText, iFlags),
 	m_pOldCommand(pConCommand)
 {
-	m_Name = szName;
+	m_Name = strdup(szName);
 }
 
 //-----------------------------------------------------------------------------
@@ -168,6 +168,8 @@ CServerCommandManager::~CServerCommandManager()
 		// Re-register the old command instance
 		g_pCVar->RegisterConCommand(m_pOldCommand);
 	}
+
+	free(m_Name);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Fixed names starting with / and ! (and probably others, as well) not being registered properly.

I'm not entirely sure this is the best way to fix, which is why I created a pull request instead of just merging into master.  It does work properly, though, for my testing with GunGame.

Before this fix, none of my say commands that started with ! or / were working.  I added some debug messages in `src/core/modules/commands/commands.h` where the comparisons are made, and all of the say commands that started with / or ! showed as a bunch of weird symbols.  That led me to believe that I needed to make copies before registering.

I believe I could also do this by storing all of these as attributes in GunGame itself, so they persist.  However, I don't necessarily believe that is the correct action to take in this instance as others might easily end up in my situation in the future without a permanent fix in SP itself.