### PR TITLE
Make SayText, SayText2 and TextMsg messages reliable by default

### DIFF
--- a/addons/source-python/packages/source-python/messages/base.py
+++ b/addons/source-python/packages/source-python/messages/base.py
@@ -42,7 +42,12 @@ class AttrDict(dict):
 
 
 class UserMessageCreator(AttrDict):
-    """Provide an easy interface to create user messages."""
+    """Provide an easy interface to create user messages.
+
+    :attr bool reliable: Whether to send message using reliable channel.
+    """
+
+    reliable = False
 
     def __init__(self, **kwargs):
         """Initialize the usermessage creator.
@@ -81,6 +86,7 @@ class UserMessageCreator(AttrDict):
         :param AttrDict translated_kwargs: The translated arguments.
         """
         recipients = RecipientFilter(*player_indexes)
+        recipients.reliable = self.reliable
         user_message = UserMessage(recipients, self.message_name)
 
         if user_message.is_protobuf():
@@ -206,6 +212,7 @@ class ShowMenu(UserMessageCreator):
         # this length, we need to sent it in several parts.
         if UserMessage.is_protobuf():
             recipients = RecipientFilter(*player_indexes)
+            recipients.reliable = self.reliable
             user_message = UserMessage(recipients, self.message_name)
             self.protobuf(user_message.buffer, self)
             user_message.send()
@@ -223,6 +230,7 @@ class ShowMenu(UserMessageCreator):
         menu_string = kwargs.menu_string
         length = len(menu_string)
         recipients = RecipientFilter(*player_indexes)
+        recipients.reliable = self.reliable
         while True:
             user_message = UserMessage(recipients, self.message_name)
 
@@ -246,6 +254,7 @@ class SayText2(UserMessageCreator):
 
     message_name = 'SayText2'
     translatable_fields = ['message', 'param1', 'param2', 'param3', 'param4']
+    reliable = True
 
     def __init__(
             self, message, index=0, chat=False,
@@ -301,6 +310,7 @@ class SayText(UserMessageCreator):
 
     message_name = 'SayText'
     translatable_fields = ['message']
+    reliable = True
 
     def __init__(self, message, index=0, chat=False):
         """Initialize the SayText instance."""
@@ -372,6 +382,7 @@ class TextMsg(UserMessageCreator):
 
     message_name = 'TextMsg'
     translatable_fields = ['message', 'param1', 'param2', 'param3', 'param4']
+    reliable = True
 
     def __init__(
             self, message, destination=HudDestination.CENTER,

--- a/addons/source-python/packages/source-python/messages/base.py
+++ b/addons/source-python/packages/source-python/messages/base.py
@@ -65,34 +65,22 @@ class UserMessageCreator(AttrDict):
 
     def send(self, *player_indexes, **tokens):
         """Send the user message."""
-        self._categorize_and_send(player_indexes, tokens, False)
-
-    def send_reliable(self, *player_indexes, **tokens):
-        """Send the user message using reliable stream.
-
-        Use this if you need to guarantee transmission of the message.
-        """
-        self._categorize_and_send(player_indexes, tokens, True)
-
-    def _categorize_and_send(self, player_indexes, tokens, reliable):
         player_indexes = RecipientFilter(*player_indexes)
         for language, indexes in self._categorize_players_by_language(
                 player_indexes).items():
             translated_kwargs = AttrDict(self)
             translated_kwargs.update(
                 self._get_translated_kwargs(language, tokens))
-            self._send(indexes, translated_kwargs, reliable)
+            self._send(indexes, translated_kwargs)
 
-    def _send(self, player_indexes, translated_kwargs, reliable):
+    def _send(self, player_indexes, translated_kwargs):
         """Send the user message to the given players.
 
         :param iterable player_indexes: All players with the same language
             setting.
         :param AttrDict translated_kwargs: The translated arguments.
-        :param bool reliable: Whether to set `RecipientFilter.reliable`.
         """
         recipients = RecipientFilter(*player_indexes)
-        recipients.reliable = reliable
         user_message = UserMessage(recipients, self.message_name)
 
         if user_message.is_protobuf():
@@ -213,22 +201,11 @@ class ShowMenu(UserMessageCreator):
 
     def send(self, *player_indexes):
         """Send the user message."""
-        self._send(player_indexes, False)
-
-    def send_reliable(self, *player_indexes):
-        """Send the user message using reliable stream.
-
-        Use this if you need to guarantee transmission of the message."""
-        self._send(player_indexes, True)
-
-    def _send(self, player_indexes, reliable):
-        """Send the user message."""
         # We need to handle the ShowMenu user message with bitbuffers
         # differently, because the maximum size is 255. If the message exceeds
         # this length, we need to sent it in several parts.
         if UserMessage.is_protobuf():
             recipients = RecipientFilter(*player_indexes)
-            recipients.reliable = reliable
             user_message = UserMessage(recipients, self.message_name)
             self.protobuf(user_message.buffer, self)
             user_message.send()


### PR DESCRIPTION
This adds `UserMessageCreator.send_reliable()` to make use of the new `RecipientFilter.reliable` attribute in https://github.com/Source-Python-Dev-Team/Source.Python/commit/cb7a8dc42d8293c75e3d0b4fe092475429139dc6 (thanks to @Ayuto for adding that!)