### PR TITLE
Added CPointWorldText data

### DIFF
--- a/addons/source-python/data/source-python/entities/csgo/CPointWorldText.ini
+++ b/addons/source-python/data/source-python/entities/csgo/CPointWorldText.ini
@@ -1,0 +1,12 @@
+[keyvalue]
+    
+    [[message]]
+        name = message
+        type = STRING
+
+
+[property]
+    
+    text = m_szText
+    text_size = m_flTextSize
+    text_color = m_textColor


### PR DESCRIPTION
Just adding some keyvalues and properties for the awesome [point_worldtext](https://developer.valvesoftware.com/wiki/Point_worldtext) entity.
The **message** keyvalue doesn't work unless it's hardcoded, not sure why.