### PR TITLE
Add SayText2 colors package to message module (fix issue #252)

### DIFF
--- a/addons/source-python/packages/source-python/messages/colors/saytext2.py
+++ b/addons/source-python/packages/source-python/messages/colors/saytext2.py
@@ -1,0 +1,69 @@
+# ../messages/colors/saytext2.py
+
+# =============================================================================
+# >> IMPORTS
+# =============================================================================
+# Source.Python Imports
+#   Color
+from colors import Color
+#   Core
+from core import GAME_NAME
+
+
+# =============================================================================
+# >> ALL DECLARATION
+# =============================================================================
+__all__ = ('BLUE',
+           'BRIGHT_GREEN',
+           'DARK_BLUE',
+           'DULL_RED',
+           'GRAY',
+           'GREEN',
+           'LIGHT_BLUE',
+           'ORANGE',
+           'PALE_GREEN',
+           'PALE_RED',
+           'PINK',
+           'RED',
+           # TEAM
+           'WHITE',
+           'YELLOW',
+           )
+
+
+# =============================================================================
+# >> GLOBAL VARIABLES
+# =============================================================================
+if GAME_NAME == 'csgo':
+    WHITE = '\x01'
+    RED = '\x02'
+    # Add TEAM color...
+    BRIGHT_GREEN = '\x04'
+    PALE_GREEN = '\x05'
+    GREEN = '\x06'
+    PALE_RED = '\x07'
+    GRAY = '\x08'
+    YELLOW = '\x09'
+    LIGHT_BLUE = '\x0A'
+    BLUE = '\x0B'
+    DARK_BLUE = '\x0C'
+    PINK = '\x0E'
+    DULL_RED = '\x0F'
+    ORANGE = '\x10'
+
+else:
+    from colors import BLUE
+    from colors import GRAY
+    from colors import GREEN
+    from colors import LIGHT_BLUE
+    from colors import LIGHT_GREEN as BRIGHT_GREEN
+    from colors import LIGHT_RED as PALE_RED
+    from colors import ORANGE
+    from colors import RED
+    from colors import WHITE
+    from colors import YELLOW
+
+    DARK_BLUE = Color(0, 0, 180)  # colors.DARK_BLUE constant is *too dark*
+    DULL_RED = Color(178, 34, 34)  # http://html-color.org/B22222
+    PALE_GREEN = Color(208, 253, 208)  # http://html-color.org/D0FDD0
+    PINK = Color(252, 116, 253)  # http://html-color.org/FC74FD


### PR DESCRIPTION
## Test Script
```python
from filters.players import PlayerIter

from messages.colors.saytext2 import GREEN
from messages.colors.saytext2 import ORANGE
from messages.colors.saytext2 import DARK_BLUE
from messages.colors.saytext2 import DULL_RED
from messages.colors.saytext2 import PINK
from messages.colors.saytext2 import DARK_BLUE
from messages.colors.saytext2 import YELLOW
from messages.colors.saytext2 import GRAY
from messages.colors.saytext2 import BRIGHT_GREEN
from messages.colors.saytext2 import RED
from messages.colors.saytext2 import BLUE
from messages.colors.saytext2 import LIGHT_BLUE
from messages.colors.saytext2 import PALE_RED
from messages.colors.saytext2 import WHITE


MY_COLORS = {
    'GREEN': GREEN,
    'ORANGE': ORANGE,
    'DULL_RED': DULL_RED,
    'PINK': PINK,
    'DARK_BLUE': DARK_BLUE,
    'YELLOW': YELLOW,
    'GRAY': GRAY,
    'BRIGHT_GREEN': BRIGHT_GREEN,
    'RED': RED,
    'BLUE': BLUE,
    'LIGHT_BLUE': LIGHT_BLUE,
    'PALE_RED': PALE_RED,
    'WHITE': WHITE
}


for player in PlayerIter('human'):
    for name, color in MY_COLORS.items():
        SayText2(f'{color}{name}').send(player.index)
```

CS:GO colors `PALE_GREEN`, `PINK` and `DULL_RED` are approximated for CS:S/OrangeBox using RGB values. `colors.DARK_BLUE` is too dark for the CS:S/OrangeBox chat box, so I changed it to `Color(0, 0, 180)`.

## Results
(ignore the `SAYTEXT2_` prefix)
### CS:S
![saytext2_css](https://user-images.githubusercontent.com/6085219/46957815-a49a9280-d098-11e8-9458-a067579fbb61.png)
### CS:GO
![saytext2_csgo](https://user-images.githubusercontent.com/6085219/46957741-7ae16b80-d098-11e8-9601-0d8448efce3c.png)

## Issues
* Team color (`\x03` for CS:GO) is not implemented. How would I go about that for CS:S/OrangeBox?
* I can't test it with games other than CS:S and CS:GO. Does this issue only apply to the two games or the engines themselves?
* What should we do for translation strings and INI files where chat colors are stored for plugins?
* Any suggestions?