### PR TITLE
Added CBaseCombatCharacter::OnTakeDamage_Alive data.

### DIFF
--- a/addons/source-python/data/source-python/entities/bms/CBaseCombatCharacter.ini
+++ b/addons/source-python/data/source-python/entities/bms/CBaseCombatCharacter.ini
@@ -1,4 +1,11 @@
 [virtual_function]
+    
+    # _ZN20CBaseCombatCharacter18OnTakeDamage_AliveERK15CTakeDamageInfo
+    [[on_take_damage_alive]]
+        offset_linux = 273
+        offset_windows = 272
+        arguments = POINTER
+        return_type = INT
 
     # _ZN20CBaseCombatCharacter13Weapon_SwitchEP17CBaseCombatWeaponi
     [[weapon_switch]]

--- a/addons/source-python/data/source-python/entities/csgo/CBaseCombatCharacter.ini
+++ b/addons/source-python/data/source-python/entities/csgo/CBaseCombatCharacter.ini
@@ -2,6 +2,13 @@ srv_check = False
 
 
 [virtual_function]
+    
+    # _ZN20CBaseCombatCharacter18OnTakeDamage_AliveERK15CTakeDamageInfo
+    [[on_take_damage_alive]]
+        offset_linux = 299
+        offset_windows = 298
+        arguments = POINTER
+        return_type = INT
 
     # _ZN20CBaseCombatCharacter13Weapon_SwitchEP17CBaseCombatWeaponi
     [[weapon_switch]]

--- a/addons/source-python/data/source-python/entities/gmod/CBaseCombatCharacter.ini
+++ b/addons/source-python/data/source-python/entities/gmod/CBaseCombatCharacter.ini
@@ -1,5 +1,12 @@
 [virtual_function]
 
+    # _ZN20CBaseCombatCharacter18OnTakeDamage_AliveERK15CTakeDamageInfo
+    [[on_take_damage_alive]]
+        offset_linux = 329
+        offset_windows = 328
+        arguments = POINTER
+        return_type = INT
+
     # _ZN20CBaseCombatCharacter13Weapon_SwitchEP17CBaseCombatWeaponi
     [[weapon_switch]]
         offset_linux = 321

--- a/addons/source-python/data/source-python/entities/l4d2/CBaseCombatCharacter.ini
+++ b/addons/source-python/data/source-python/entities/l4d2/CBaseCombatCharacter.ini
@@ -1,5 +1,12 @@
 [virtual_function]
 
+    # _ZN20CBaseCombatCharacter18OnTakeDamage_AliveERK15CTakeDamageInfo
+    [[on_take_damage_alive]]
+        offset_linux = 292
+        offset_windows = 291
+        arguments = POINTER
+        return_type = INT
+
     # _ZN20CBaseCombatCharacter13Weapon_SwitchEP17CBaseCombatWeaponi
     [[weapon_switch]]
         offset_linux = 284

--- a/addons/source-python/data/source-python/entities/orangebox/CBaseCombatCharacter.ini
+++ b/addons/source-python/data/source-python/entities/orangebox/CBaseCombatCharacter.ini
@@ -1,5 +1,12 @@
 [virtual_function]
 
+    # _ZN20CBaseCombatCharacter18OnTakeDamage_AliveERK15CTakeDamageInfo
+    [[on_take_damage_alive]]
+        offset_linux = 273
+        offset_windows = 272
+        arguments = POINTER
+        return_type = INT
+
     # _ZN20CBaseCombatCharacter13Weapon_SwitchEP17CBaseCombatWeaponi
     [[weapon_switch]]
         offset_linux = 265

--- a/addons/source-python/data/source-python/entities/orangebox/tf/CBaseCombatCharacter.ini
+++ b/addons/source-python/data/source-python/entities/orangebox/tf/CBaseCombatCharacter.ini
@@ -1,5 +1,12 @@
 [virtual_function]
 
+    # _ZN20CBaseCombatCharacter18OnTakeDamage_AliveERK15CTakeDamageInfo
+    [[on_take_damage_alive]]
+        offset_linux = 276
+        offset_windows = 275
+        arguments = POINTER
+        return_type = INT
+
     # _ZN20CBaseCombatCharacter13Weapon_SwitchEP17CBaseCombatWeaponi
     [[weapon_switch]]
         offset_linux = 268


### PR DESCRIPTION
When working with armor (CSS, CSGO) or critical hits (TF2), [CBaseEntity::OnTakeDamage](https://github.com/alliedmodders/hl2sdk/blob/0ef5d3d482157bc0bb3aafd37c08961373f87bfd/game/server/baseentity.cpp#L1376) gives incorrect values. I found out that [CBaseCombatCharacter::OnTakeDamage_Alive](https://github.com/alliedmodders/hl2sdk/blob/0ef5d3d482157bc0bb3aafd37c08961373f87bfd/game/server/basecombatcharacter.cpp#L2463) gives the correct values, so I've added the data for all supported games.

```python
# ../damage_comparison/damage_comparison.py

# Source.Python
from entities import TakeDamageInfo
from entities.entity import BaseEntity
from entities.hooks import EntityCondition, EntityPreHook


@EntityPreHook(EntityCondition.is_player, 'on_take_damage')
def on_take_damage_pre(stack_data):
    base_entity = BaseEntity._obj(stack_data[0])
    info = TakeDamageInfo._obj(stack_data[1])

    print(f'otd:   player({base_entity.index}) took {info.damage} damage')


@EntityPreHook(EntityCondition.is_player, 'on_take_damage_alive')
def on_take_damage_alive_pre(stack_data):
    base_entity = BaseEntity._obj(stack_data[0])
    info = TakeDamageInfo._obj(stack_data[1])

    print(f'otd_a: player({base_entity.index}) took {info.damage} damage')
```
Output (from CSGO):
```
otd:   player(5) took 28.294065475463867 damage
otd_a: player(5) took 13.0 damage
```
I wasn't sure where to add the data for Blade Symphony, but it does have the same offset as Left 4 Dead 2, are these two games on the same Source engine branch?