### PR TITLE
Player class updates

### DIFF
--- a/addons/source-python/data/source-python/entities/CBaseEntity.ini
+++ b/addons/source-python/data/source-python/entities/CBaseEntity.ini
@@ -23,64 +23,12 @@
 
 [keyvalue]
 
-    avelocity = avelocity
-    base_velocity = basevelocity
-    class_name = classname
-    damage_filter = damagefilter
-    effects = effects
-    friction = friction
-    global_name = globalname
-    gravity = gravity
-    hammerid = hammerid
-    health = health
-    ltime = ltime
-    max_health = max_health
-    parent_name = parentname
-    render_color = rendercolor
-    render_mode = rendermode
-    shadow_cast_dist = shadowcastdist
-    spawn_flags = spawnflags
-    speed = speed
-    target = target
-    velocity = velocity
     view_ofs = view_ofs
-    water_level = waterlevel
 
     # =========================================================================
     # >> Hard-coded KeyValues
     # =========================================================================
 
-    [[angles]]
-        name = angles
-        type = VECTOR
-
-    [[origin]]
-        name = origin
-        type = VECTOR
-
     [[render_amt]]
         name = renderamt
         type = SHORT
-
-    [[target_name]]
-        name = targetname
-        type = STRING
-
-
-[property]
-
-    maxs = m_Collision.m_vecMaxs
-    mins = m_Collision.m_vecMins
-    solid_type = m_Collision.m_nSolidType
-    solid_flags = m_Collision.m_usSolidFlags
-    collision_group = m_CollisionGroup
-    rotation = m_angRotation
-    render = m_clrRender
-    elasticity = m_flElasticity
-    ground_entity = m_hGroundEntity
-    owner_handle = m_hOwnerEntity
-    team_index = m_iTeamNum
-    render_fx = m_nRenderFX
-    render_mode_prop = m_nRenderMode
-    move_type = movetype
-    parent_inthandle = m_pParent

--- a/addons/source-python/docs/source-python/source/developing/modules/players._base.rst
+++ b/addons/source-python/docs/source-python/source/developing/modules/players._base.rst
@@ -5,3 +5,8 @@ players._base module
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. autoclass:: _players.PlayerMixin
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/addons/source-python/packages/source-python/players/_base.py
+++ b/addons/source-python/packages/source-python/players/_base.py
@@ -55,6 +55,7 @@ from mathlib import QAngle
 from memory import get_object_pointer
 from memory import make_object
 #   Players
+from _players import _Player # Mixin class to speed up things
 from players.constants import PlayerStates
 from players.helpers import address_from_playerinfo
 from players.helpers import get_client_language
@@ -73,7 +74,7 @@ from auth.manager import auth_manager
 # =============================================================================
 # >> CLASSES
 # =============================================================================
-class Player(Entity):
+class Player(Entity, _Player):
     """Class used to interact directly with players."""
 
     def __init__(self, index):

--- a/addons/source-python/packages/source-python/players/_base.py
+++ b/addons/source-python/packages/source-python/players/_base.py
@@ -55,7 +55,7 @@ from mathlib import QAngle
 from memory import get_object_pointer
 from memory import make_object
 #   Players
-from _players import _Player # Mixin class to speed up things
+from _players import PlayerMixin
 from players.constants import PlayerStates
 from players.helpers import address_from_playerinfo
 from players.helpers import get_client_language
@@ -74,7 +74,7 @@ from auth.manager import auth_manager
 # =============================================================================
 # >> CLASSES
 # =============================================================================
-class Player(Entity, _Player):
+class Player(Entity, PlayerMixin):
     """Class used to interact directly with players."""
 
     def __init__(self, index):

--- a/addons/source-python/packages/source-python/players/_base.py
+++ b/addons/source-python/packages/source-python/players/_base.py
@@ -381,24 +381,6 @@ class Player(Entity, _Player):
 
     eye_location = property(Entity.get_eye_location, set_eye_location)
 
-    @property
-    def view_vector(self):
-        """Return the view vector of the player.
-
-        :rtype: Vector
-        """
-        eye_angle = self.eye_angle
-
-        yaw = math.radians(eye_angle.y)
-        pitch = math.radians(eye_angle.x)
-
-        sy = math.sin(yaw)
-        cy = math.cos(yaw)
-        sp = math.sin(pitch)
-        cp = math.cos(pitch)
-
-        return Vector(cp * cy, cp * sy, -sp)
-
     def get_view_angle(self):
         """Return the player's view angle.
 

--- a/addons/source-python/packages/source-python/players/_base.py
+++ b/addons/source-python/packages/source-python/players/_base.py
@@ -386,10 +386,7 @@ class Player(Entity, _Player):
 
         :rtype: QAngle
         """
-        eye_angle = self.eye_angle
-        eye_angle_y = eye_angle.y
-        eye_angle_y = (eye_angle_y + 360) if eye_angle_y < 0 else eye_angle_y
-        return QAngle(eye_angle.x, eye_angle_y, self.rotation.z)
+        return super().view_angle
 
     def set_view_angle(self, angle):
         """Set the player's view angle."""

--- a/addons/source-python/packages/source-python/players/engines/csgo/__init__.py
+++ b/addons/source-python/packages/source-python/players/engines/csgo/__init__.py
@@ -43,7 +43,7 @@ class Player(_Player):
 
     def _get_kills(self):
         """Return the number of kills the player has."""
-        return self.__getattr__('kills')
+        return super().kills
 
     def _set_kills(self, value):
         """Set the number of kills the player has."""
@@ -54,7 +54,7 @@ class Player(_Player):
 
     def _get_deaths(self):
         """Return the number of deaths the player has."""
-        return self.__getattr__('deaths')
+        return super().deaths
 
     def _set_deaths(self, value):
         """Set the number of deaths the player has."""
@@ -65,7 +65,7 @@ class Player(_Player):
 
     def _get_assists(self):
         """Return the number of assists the player has."""
-        return self.__getattr__('assists')
+        return super().assists
 
     def _set_assists(self, value):
         """Set the number of assists the player has."""

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -381,6 +381,7 @@ Set(SOURCEPYTHON_PHYSICS_MODULE_SOURCES
 # ------------------------------------------------------------------
 Set(SOURCEPYTHON_PLAYERS_MODULE_HEADERS
     core/modules/players/players_wrap.h
+    core/modules/players/players_entity.h
     core/modules/players/players_generator.h
     core/modules/players/${SOURCE_ENGINE}/players_constants_wrap.h
     core/modules/players/${SOURCE_ENGINE}/players_wrap.h
@@ -389,6 +390,7 @@ Set(SOURCEPYTHON_PLAYERS_MODULE_HEADERS
 Set(SOURCEPYTHON_PLAYERS_MODULE_SOURCES
     core/modules/players/players_bots_wrap.cpp
     core/modules/players/players_constants_wrap.cpp
+    core/modules/players/players_entity.cpp
     core/modules/players/players_helpers_wrap.cpp
     core/modules/players/players_wrap.cpp
     core/modules/players/players_generator.cpp

--- a/src/core/modules/entities/entities_entity.h
+++ b/src/core/modules/entities/entities_entity.h
@@ -80,7 +80,7 @@ public:
 //-----------------------------------------------------------------------------
 class CBaseEntityWrapper: public IServerEntity
 {
-private:
+protected:
 	// Make sure that nobody can call the constructor/destructor
 	CBaseEntityWrapper() {}
 	~CBaseEntityWrapper() {}

--- a/src/core/modules/entities/entities_entity_wrap.cpp
+++ b/src/core/modules/entities/entities_entity_wrap.cpp
@@ -333,7 +333,7 @@ void export_base_entity(scope _entity)
 		&CBaseEntityWrapper::GetParentName,
 		&CBaseEntityWrapper::SetParentName,
 		"Get/set the entity's parent name.\n\n"
-		":rtype: int"
+		":rtype: str"
 	);
 
 	BaseEntity.add_property(

--- a/src/core/modules/entities/entities_entity_wrap.cpp
+++ b/src/core/modules/entities/entities_entity_wrap.cpp
@@ -329,6 +329,14 @@ void export_base_entity(scope _entity)
 	);
 
 	BaseEntity.add_property(
+		"parent_name",
+		&CBaseEntityWrapper::GetParentName,
+		&CBaseEntityWrapper::SetParentName,
+		"Get/set the entity's parent name.\n\n"
+		":rtype: int"
+	);
+
+	BaseEntity.add_property(
 		"shadow_cast_distance",
 		&CBaseEntityWrapper::GetShadowCastDistance,
 		&CBaseEntityWrapper::SetShadowCastDistance,

--- a/src/core/modules/players/players_entity.cpp
+++ b/src/core/modules/players/players_entity.cpp
@@ -38,7 +38,7 @@ boost::shared_ptr<PlayerWrapper> PlayerWrapper::__init__(unsigned int uiEntityIn
 {
 	CBaseEntityWrapper* pEntity = (CBaseEntityWrapper*) ExcBaseEntityFromIndex(uiEntityIndex);
 	if (!pEntity->IsPlayer())
-		BOOST_RAISE_EXCEPTION(PyExc_ValueError, "Index '%d' is not a valid player.");
+		BOOST_RAISE_EXCEPTION(PyExc_ValueError, "Index '%d' is not a valid player.", uiEntityIndex);
 
 	return PlayerWrapper::wrap(pEntity->GetBaseEntity());
 }

--- a/src/core/modules/players/players_entity.cpp
+++ b/src/core/modules/players/players_entity.cpp
@@ -32,294 +32,294 @@
 
 
 // ============================================================================
-// >> PlayerWrapper
+// >> PlayerMixin
 // ============================================================================
-boost::shared_ptr<PlayerWrapper> PlayerWrapper::__init__(unsigned int uiEntityIndex)
+boost::shared_ptr<PlayerMixin> PlayerMixin::__init__(unsigned int uiEntityIndex)
 {
 	CBaseEntityWrapper* pEntity = (CBaseEntityWrapper*) ExcBaseEntityFromIndex(uiEntityIndex);
 	if (!pEntity->IsPlayer())
 		BOOST_RAISE_EXCEPTION(PyExc_ValueError, "Index '%d' is not a valid player.", uiEntityIndex);
 
-	return PlayerWrapper::wrap(pEntity->GetBaseEntity());
+	return PlayerMixin::wrap(pEntity->GetBaseEntity());
 }
 
-boost::shared_ptr<PlayerWrapper> PlayerWrapper::wrap(CBaseEntity* pEntity)
+boost::shared_ptr<PlayerMixin> PlayerMixin::wrap(CBaseEntity* pEntity)
 {
-	return boost::shared_ptr<PlayerWrapper>(
-		(PlayerWrapper *) pEntity,
-		&NeverDeleteDeleter<PlayerWrapper *>
+	return boost::shared_ptr<PlayerMixin>(
+		(PlayerMixin *) pEntity,
+		&NeverDeleteDeleter<PlayerMixin *>
 	);
 }
 
 
 // CBasePlayer
-float PlayerWrapper::GetSpeed()
+float PlayerMixin::GetSpeed()
 {
 	static int offset = FindNetworkPropertyOffset("localdata.m_flLaggedMovementValue");
 	return GetNetworkPropertyByOffset<float>(offset);
 }
 
-void PlayerWrapper::SetSpeed(float value)
+void PlayerMixin::SetSpeed(float value)
 {
 	static int offset = FindNetworkPropertyOffset("localdata.m_flLaggedMovementValue");
 	SetNetworkPropertyByOffset<float>(offset, value);
 }
 
 
-bool PlayerWrapper::GetIsDucked()
+bool PlayerMixin::GetIsDucked()
 {
 	static int offset = FindDatamapPropertyOffset("m_Local.m_bDucked");
 	return GetDatamapPropertyByOffset<bool>(offset);
 }
 
-void PlayerWrapper::SetIsDucked(bool value)
+void PlayerMixin::SetIsDucked(bool value)
 {
 	static int offset = FindDatamapPropertyOffset("m_Local.m_bDucked");
 	SetDatamapPropertyByOffset<bool>(offset, value);
 }
 
 
-bool PlayerWrapper::GetIsDucking()
+bool PlayerMixin::GetIsDucking()
 {
 	static int offset = FindDatamapPropertyOffset("m_Local.m_bDucking");
 	return GetDatamapPropertyByOffset<bool>(offset);
 }
 
-void PlayerWrapper::SetIsDucking(bool value)
+void PlayerMixin::SetIsDucking(bool value)
 {
 	static int offset = FindDatamapPropertyOffset("m_Local.m_bDucking");
 	SetDatamapPropertyByOffset<bool>(offset, value);
 }
 
 
-int PlayerWrapper::GetFlags()
+int PlayerMixin::GetFlags()
 {
 	static int offset = FindNetworkPropertyOffset("m_fFlags");
 	return GetNetworkPropertyByOffset<int>(offset);
 }
 
-void PlayerWrapper::SetFlags(int value)
+void PlayerMixin::SetFlags(int value)
 {
 	static int offset = FindNetworkPropertyOffset("m_fFlags");
 	SetNetworkPropertyByOffset<int>(offset, value);
 }
 
 
-int PlayerWrapper::GetLastWeapon()
+int PlayerMixin::GetLastWeapon()
 {
 	static int offset = FindNetworkPropertyOffset("localdata.m_hLastWeapon");
 	return GetNetworkPropertyByOffset<int>(offset);
 }
 
-void PlayerWrapper::SetLastWeapon(int value)
+void PlayerMixin::SetLastWeapon(int value)
 {
 	static int offset = FindNetworkPropertyOffset("localdata.m_hLastWeapon");
 	SetNetworkPropertyByOffset<int>(offset, value);
 }
 
 
-int PlayerWrapper::GetObserverTarget()
+int PlayerMixin::GetObserverTarget()
 {
 	static int offset = FindNetworkPropertyOffset("m_hObserverTarget");
 	return GetNetworkPropertyByOffset<int>(offset);
 }
 
-void PlayerWrapper::SetObserverTarget(int value)
+void PlayerMixin::SetObserverTarget(int value)
 {
 	static int offset = FindNetworkPropertyOffset("m_hObserverTarget");
 	SetNetworkPropertyByOffset<int>(offset, value);
 }
 
 
-int PlayerWrapper::GetDeaths()
+int PlayerMixin::GetDeaths()
 {
 	static int offset = FindDatamapPropertyOffset("m_iDeaths");
 	return GetDatamapPropertyByOffset<int>(offset);
 }
 
-void PlayerWrapper::SetDeaths(int value)
+void PlayerMixin::SetDeaths(int value)
 {
 	static int offset = FindDatamapPropertyOffset("m_iDeaths");
 	SetDatamapPropertyByOffset<int>(offset, value);
 }
 
 
-int PlayerWrapper::GetKills()
+int PlayerMixin::GetKills()
 {
 	static int offset = FindDatamapPropertyOffset("m_iFrags");
 	return GetDatamapPropertyByOffset<int>(offset);
 }
 
-void PlayerWrapper::SetKills(int value)
+void PlayerMixin::SetKills(int value)
 {
 	static int offset = FindDatamapPropertyOffset("m_iFrags");
 	SetDatamapPropertyByOffset<int>(offset, value);
 }
 
 
-int PlayerWrapper::GetObserverMode()
+int PlayerMixin::GetObserverMode()
 {
 	static int offset = FindNetworkPropertyOffset("m_iObserverMode");
 	return GetNetworkPropertyByOffset<int>(offset);
 }
 
-void PlayerWrapper::SetObserverMode(int value)
+void PlayerMixin::SetObserverMode(int value)
 {
 	static int offset = FindNetworkPropertyOffset("m_iObserverMode");
 	SetNetworkPropertyByOffset<int>(offset, value);
 }
 
 
-int PlayerWrapper::GetLifeState()
+int PlayerMixin::GetLifeState()
 {
 	static int offset = FindNetworkPropertyOffset("m_lifeState");
 	return GetNetworkPropertyByOffset<int>(offset);
 }
 
-void PlayerWrapper::SetLifeState(int value)
+void PlayerMixin::SetLifeState(int value)
 {
 	static int offset = FindNetworkPropertyOffset("m_lifeState");
 	SetNetworkPropertyByOffset<int>(offset, value);
 }
 
 
-str PlayerWrapper::GetPlace()
+str PlayerMixin::GetPlace()
 {
 	static int offset = FindNetworkPropertyOffset("m_szLastPlaceName");
 	return str(GetNetworkPropertyStringArrayByOffset(offset));
 }
 
-void PlayerWrapper::SetPlace(const char* value)
+void PlayerMixin::SetPlace(const char* value)
 {
 	static int offset = FindNetworkPropertyOffset("m_szLastPlaceName");
 	SetNetworkPropertyStringArrayByOffset(offset, value);
 }
 
 
-bool PlayerWrapper::GetDead()
+bool PlayerMixin::GetDead()
 {
 	static int offset = FindNetworkPropertyOffset("pl.deadflag");
 	return GetNetworkPropertyByOffset<bool>(offset);
 }
 
-void PlayerWrapper::SetDead(bool value)
+void PlayerMixin::SetDead(bool value)
 {
 	static int offset = FindNetworkPropertyOffset("pl.deadflag");
 	SetNetworkPropertyByOffset<bool>(offset, value);
 }
 
 
-float PlayerWrapper::GetFallVelocity()
+float PlayerMixin::GetFallVelocity()
 {
 	static int offset = FindDatamapPropertyOffset("m_Local.m_flFallVelocity");
 	return GetDatamapPropertyByOffset<float>(offset);
 }
 
-void PlayerWrapper::SetFallVelocity(float value)
+void PlayerMixin::SetFallVelocity(float value)
 {
 	static int offset = FindDatamapPropertyOffset("m_Local.m_flFallVelocity");
 	SetDatamapPropertyByOffset<float>(offset, value);
 }
 
 
-int PlayerWrapper::GetButtons()
+int PlayerMixin::GetButtons()
 {
 	static int offset = FindDatamapPropertyOffset("m_nButtons");
 	return GetDatamapPropertyByOffset<int>(offset);
 }
 
-void PlayerWrapper::SetButtons(int value)
+void PlayerMixin::SetButtons(int value)
 {
 	static int offset = FindDatamapPropertyOffset("m_nButtons");
 	SetDatamapPropertyByOffset<int>(offset, value);
 }
 
 
-int PlayerWrapper::GetHiddenHUDs()
+int PlayerMixin::GetHiddenHUDs()
 {
 	static int offset = FindDatamapPropertyOffset("m_Local.m_iHideHUD");
 	return GetDatamapPropertyByOffset<int>(offset);
 }
 
-void PlayerWrapper::SetHiddenHUDs(int value)
+void PlayerMixin::SetHiddenHUDs(int value)
 {
 	static int offset = FindDatamapPropertyOffset("m_Local.m_iHideHUD");
 	SetDatamapPropertyByOffset<int>(offset, value);
 }
 
 
-int PlayerWrapper::GetDrawViewModel()
+int PlayerMixin::GetDrawViewModel()
 {
 	static int offset = FindDatamapPropertyOffset("m_Local.m_bDrawViewmodel");
 	return GetDatamapPropertyByOffset<int>(offset);
 }
 
-void PlayerWrapper::SetDrawViewModel(int value)
+void PlayerMixin::SetDrawViewModel(int value)
 {
 	static int offset = FindDatamapPropertyOffset("m_Local.m_bDrawViewmodel");
 	SetDatamapPropertyByOffset<int>(offset, value);
 }
 
 
-int PlayerWrapper::GetFOV()
+int PlayerMixin::GetFOV()
 {
 	static int offset = FindNetworkPropertyOffset("m_iFOV");
 	return GetNetworkPropertyByOffset<int>(offset);
 }
 
-void PlayerWrapper::SetFOV(int value)
+void PlayerMixin::SetFOV(int value)
 {
 	static int offset = FindNetworkPropertyOffset("m_iFOV");
 	SetNetworkPropertyByOffset<int>(offset, value);
 }
 
 
-int PlayerWrapper::GetFOVStart()
+int PlayerMixin::GetFOVStart()
 {
 	static int offset = FindNetworkPropertyOffset("m_iFOVStart");
 	return GetNetworkPropertyByOffset<int>(offset);
 }
 
-void PlayerWrapper::SetFOVStart(int value)
+void PlayerMixin::SetFOVStart(int value)
 {
 	static int offset = FindNetworkPropertyOffset("m_iFOVStart");
 	SetNetworkPropertyByOffset<int>(offset, value);
 }
 
 
-float PlayerWrapper::GetFOVTime()
+float PlayerMixin::GetFOVTime()
 {
 	static int offset = FindNetworkPropertyOffset("m_flFOVTime");
 	return GetNetworkPropertyByOffset<float>(offset);
 }
 
-void PlayerWrapper::SetFOVTime(float value)
+void PlayerMixin::SetFOVTime(float value)
 {
 	static int offset = FindNetworkPropertyOffset("m_flFOVTime");
 	SetNetworkPropertyByOffset<float>(offset, value);
 }
 
 
-int PlayerWrapper::GetDefaultFOV()
+int PlayerMixin::GetDefaultFOV()
 {
 	static int offset = FindNetworkPropertyOffset("m_iDefaultFOV");
 	return GetNetworkPropertyByOffset<int>(offset);
 }
 
-void PlayerWrapper::SetDefaultFOV(int value)
+void PlayerMixin::SetDefaultFOV(int value)
 {
 	static int offset = FindNetworkPropertyOffset("m_iDefaultFOV");
 	SetNetworkPropertyByOffset<int>(offset, value);
 }
 
 
-float PlayerWrapper::GetFOVRate()
+float PlayerMixin::GetFOVRate()
 {
 	static int offset = FindDatamapPropertyOffset("m_Local.m_flFOVRate");
 	return GetDatamapPropertyByOffset<float>(offset);
 }
 
-void PlayerWrapper::SetFOVRate(float value)
+void PlayerMixin::SetFOVRate(float value)
 {
 	static int offset = FindDatamapPropertyOffset("m_Local.m_flFOVRate");
 	SetDatamapPropertyByOffset<float>(offset, value);
@@ -327,68 +327,68 @@ void PlayerWrapper::SetFOVRate(float value)
 
 
 // CBaseCombatCharacter
-Vector PlayerWrapper::GetGunOffset()
+Vector PlayerMixin::GetGunOffset()
 {
 	static int offset = FindDatamapPropertyOffset("m_HackedGunPos");
 	return GetDatamapPropertyByOffset<Vector>(offset);
 }
 
-void PlayerWrapper::SetGunOffset(Vector& value)
+void PlayerMixin::SetGunOffset(Vector& value)
 {
 	static int offset = FindDatamapPropertyOffset("m_HackedGunPos");
 	SetDatamapPropertyByOffset<Vector>(offset, value);
 }
 
 
-int PlayerWrapper::GetLastHitgroup()
+int PlayerMixin::GetLastHitgroup()
 {
 	static int offset = FindDatamapPropertyOffset("m_LastHitGroup");
 	return GetDatamapPropertyByOffset<int>(offset);
 }
 
-void PlayerWrapper::SetLastHitgroup(int value)
+void PlayerMixin::SetLastHitgroup(int value)
 {
 	static int offset = FindDatamapPropertyOffset("m_LastHitGroup");
 	SetDatamapPropertyByOffset<int>(offset, value);
 }
 
 
-int PlayerWrapper::GetActiveWeaponHandle()
+int PlayerMixin::GetActiveWeaponHandle()
 {
 	static int offset = FindNetworkPropertyOffset("m_hActiveWeapon");
 	return GetNetworkPropertyByOffset<int>(offset);
 }
 
-void PlayerWrapper::SetActiveWeaponHandle(int value)
+void PlayerMixin::SetActiveWeaponHandle(int value)
 {
 	static int offset = FindNetworkPropertyOffset("m_hActiveWeapon");
 	SetNetworkPropertyByOffset<int>(offset, value);
 }
 
 
-str PlayerWrapper::GetRelationship()
+str PlayerMixin::GetRelationship()
 {
 	return GetKeyValueString("Relationship");
 }
 
-void PlayerWrapper::SetRelationship(const char* value)
+void PlayerMixin::SetRelationship(const char* value)
 {
 	SetKeyValue("Relationship", value);
 }
 
 
-float PlayerWrapper::GetPhysDamageScale()
+float PlayerMixin::GetPhysDamageScale()
 {
 	return GetKeyValueFloat("physdamagescale");
 }
 
-void PlayerWrapper::SetPhysDamageScale(float value)
+void PlayerMixin::SetPhysDamageScale(float value)
 {
 	SetKeyValue("physdamagescale", value);
 }
 
 
-QAngle PlayerWrapper::GetEyeAngle()
+QAngle PlayerMixin::GetEyeAngle()
 {
 	static int offset_x = FindNetworkPropertyOffset(EYE_ANGLE_PROPERTY(0));
 	static int offset_y = FindNetworkPropertyOffset(EYE_ANGLE_PROPERTY(1));
@@ -398,7 +398,7 @@ QAngle PlayerWrapper::GetEyeAngle()
 		0);
 }
 
-void PlayerWrapper::SetEyeAngle(QAngle& value)
+void PlayerMixin::SetEyeAngle(QAngle& value)
 {
 	static int offset_x = FindNetworkPropertyOffset(EYE_ANGLE_PROPERTY(0));
 	static int offset_y = FindNetworkPropertyOffset(EYE_ANGLE_PROPERTY(1));
@@ -407,7 +407,7 @@ void PlayerWrapper::SetEyeAngle(QAngle& value)
 }
 
 
-Vector PlayerWrapper::GetViewVector()
+Vector PlayerMixin::GetViewVector()
 {
 	QAngle eye_angle = GetEyeAngle();
 
@@ -421,13 +421,13 @@ Vector PlayerWrapper::GetViewVector()
 	return Vector(cp * cy, cp * sy, -sp);
 }
 
-void PlayerWrapper::SetViewVector(Vector& value)
+void PlayerMixin::SetViewVector(Vector& value)
 {
 	BOOST_RAISE_EXCEPTION(PyExc_NotImplementedError, "Setting view_vector is not implemented.");
 }
 
 
-QAngle PlayerWrapper::GetViewAngle()
+QAngle PlayerMixin::GetViewAngle()
 {
 	QAngle eye_angle = GetEyeAngle();
 	return QAngle(
@@ -436,266 +436,266 @@ QAngle PlayerWrapper::GetViewAngle()
 		GetRotation().z);
 }
 
-void PlayerWrapper::SetViewAngle(QAngle& value)
+void PlayerMixin::SetViewAngle(QAngle& value)
 {
 	BOOST_RAISE_EXCEPTION(PyExc_NotImplementedError, "Setting view_angle is not implemented.");
 }
 
 
-float PlayerWrapper::GetStamina()
+float PlayerMixin::GetStamina()
 {
 	static int offset = FindNetworkPropertyOffset("cslocaldata.m_flStamina");
 	return GetNetworkPropertyByOffset<float>(offset);
 }
 
-void PlayerWrapper::SetStamina(float value)
+void PlayerMixin::SetStamina(float value)
 {
 	static int offset = FindNetworkPropertyOffset("cslocaldata.m_flStamina");
 	SetNetworkPropertyByOffset<float>(offset, value);
 }
 
 
-int PlayerWrapper::GetShotsFired()
+int PlayerMixin::GetShotsFired()
 {
 	static int offset = FindNetworkPropertyOffset("cslocaldata.m_iShotsFired");
 	return GetNetworkPropertyByOffset<float>(offset);
 }
 
-void PlayerWrapper::SetShotsFired(int value)
+void PlayerMixin::SetShotsFired(int value)
 {
 	static int offset = FindNetworkPropertyOffset("cslocaldata.m_iShotsFired");
 	SetNetworkPropertyByOffset<float>(offset, value);
 }
 
 
-int PlayerWrapper::GetArmor()
+int PlayerMixin::GetArmor()
 {
 	static int offset = FindNetworkPropertyOffset("m_ArmorValue");
 	return GetNetworkPropertyByOffset<int>(offset);
 }
 
-void PlayerWrapper::SetArmor(int value)
+void PlayerMixin::SetArmor(int value)
 {
 	static int offset = FindNetworkPropertyOffset("m_ArmorValue");
 	SetNetworkPropertyByOffset<int>(offset, value);
 }
 
 
-bool PlayerWrapper::GetHasDefuser()
+bool PlayerMixin::GetHasDefuser()
 {
 	static int offset = FindNetworkPropertyOffset("m_bHasDefuser");
 	return GetNetworkPropertyByOffset<bool>(offset);
 }
 
-void PlayerWrapper::SetHasDefuser(bool value)
+void PlayerMixin::SetHasDefuser(bool value)
 {
 	static int offset = FindNetworkPropertyOffset("m_bHasDefuser");
 	SetNetworkPropertyByOffset<bool>(offset, value);
 }
 
 
-bool PlayerWrapper::GetHasHelmet()
+bool PlayerMixin::GetHasHelmet()
 {
 	static int offset = FindNetworkPropertyOffset("m_bHasHelmet");
 	return GetNetworkPropertyByOffset<bool>(offset);
 }
 
-void PlayerWrapper::SetHasHelmet(bool value)
+void PlayerMixin::SetHasHelmet(bool value)
 {
 	static int offset = FindNetworkPropertyOffset("m_bHasHelmet");
 	SetNetworkPropertyByOffset<bool>(offset, value);
 }
 
 
-bool PlayerWrapper::GetHasNightvision()
+bool PlayerMixin::GetHasNightvision()
 {
 	static int offset = FindNetworkPropertyOffset("m_bHasNightVision");
 	return GetNetworkPropertyByOffset<bool>(offset);
 }
 
-void PlayerWrapper::SetHasNightvision(bool value)
+void PlayerMixin::SetHasNightvision(bool value)
 {
 	static int offset = FindNetworkPropertyOffset("m_bHasNightVision");
 	SetNetworkPropertyByOffset<bool>(offset, value);
 }
 
 
-bool PlayerWrapper::GetIsInBombZone()
+bool PlayerMixin::GetIsInBombZone()
 {
 	static int offset = FindNetworkPropertyOffset("m_bInBombZone");
 	return GetNetworkPropertyByOffset<bool>(offset);
 }
 
-void PlayerWrapper::SetIsInBombZone(bool value)
+void PlayerMixin::SetIsInBombZone(bool value)
 {
 	static int offset = FindNetworkPropertyOffset("m_bInBombZone");
 	SetNetworkPropertyByOffset<bool>(offset, value);
 }
 
 
-bool PlayerWrapper::GetIsInBuyZone()
+bool PlayerMixin::GetIsInBuyZone()
 {
 	static int offset = FindNetworkPropertyOffset("m_bInBuyZone");
 	return GetNetworkPropertyByOffset<bool>(offset);
 }
 
-void PlayerWrapper::SetIsInBuyZone(bool value)
+void PlayerMixin::SetIsInBuyZone(bool value)
 {
 	static int offset = FindNetworkPropertyOffset("m_bInBuyZone");
 	SetNetworkPropertyByOffset<bool>(offset, value);
 }
 
 
-bool PlayerWrapper::GetIsInHostageRescueZone()
+bool PlayerMixin::GetIsInHostageRescueZone()
 {
 	static int offset = FindNetworkPropertyOffset("m_bInHostageRescueZone");
 	return GetNetworkPropertyByOffset<bool>(offset);
 }
 
-void PlayerWrapper::SetIsInHostageRescueZone(bool value)
+void PlayerMixin::SetIsInHostageRescueZone(bool value)
 {
 	static int offset = FindNetworkPropertyOffset("m_bInHostageRescueZone");
 	SetNetworkPropertyByOffset<bool>(offset, value);
 }
 
 
-bool PlayerWrapper::GetIsDefusing()
+bool PlayerMixin::GetIsDefusing()
 {
 	static int offset = FindNetworkPropertyOffset("m_bIsDefusing");
 	return GetNetworkPropertyByOffset<bool>(offset);
 }
 
-void PlayerWrapper::SetIsDefusing(bool value)
+void PlayerMixin::SetIsDefusing(bool value)
 {
 	static int offset = FindNetworkPropertyOffset("m_bIsDefusing");
 	SetNetworkPropertyByOffset<bool>(offset, value);
 }
 
 
-bool PlayerWrapper::GetNightvisionOn()
+bool PlayerMixin::GetNightvisionOn()
 {
 	static int offset = FindNetworkPropertyOffset("m_bNightVisionOn");
 	return GetNetworkPropertyByOffset<bool>(offset);
 }
 
-void PlayerWrapper::SetNightvisionOn(bool value)
+void PlayerMixin::SetNightvisionOn(bool value)
 {
 	static int offset = FindNetworkPropertyOffset("m_bNightVisionOn");
 	SetNetworkPropertyByOffset<bool>(offset, value);
 }
 
 
-float PlayerWrapper::GetFlashDuration()
+float PlayerMixin::GetFlashDuration()
 {
 	static int offset = FindNetworkPropertyOffset("m_flFlashDuration");
 	return GetNetworkPropertyByOffset<float>(offset);
 }
 
-void PlayerWrapper::SetFlashDuration(float value)
+void PlayerMixin::SetFlashDuration(float value)
 {
 	static int offset = FindNetworkPropertyOffset("m_flFlashDuration");
 	SetNetworkPropertyByOffset<float>(offset, value);
 }
 
 
-float PlayerWrapper::GetFlashAlpha()
+float PlayerMixin::GetFlashAlpha()
 {
 	static int offset = FindNetworkPropertyOffset("m_flFlashMaxAlpha");
 	return GetNetworkPropertyByOffset<float>(offset);
 }
 
-void PlayerWrapper::SetFlashAlpha(float value)
+void PlayerMixin::SetFlashAlpha(float value)
 {
 	static int offset = FindNetworkPropertyOffset("m_flFlashMaxAlpha");
 	SetNetworkPropertyByOffset<float>(offset, value);
 }
 
 
-int PlayerWrapper::GetCash()
+int PlayerMixin::GetCash()
 {
 	static int offset = FindNetworkPropertyOffset("m_iAccount");
 	return GetNetworkPropertyByOffset<int>(offset);
 }
 
-void PlayerWrapper::SetCash(int value)
+void PlayerMixin::SetCash(int value)
 {
 	static int offset = FindNetworkPropertyOffset("m_iAccount");
 	SetNetworkPropertyByOffset<int>(offset, value);
 }
 
 
-int PlayerWrapper::GetPlayerClass()
+int PlayerMixin::GetPlayerClass()
 {
 	static int offset = FindNetworkPropertyOffset(PLAYER_CLASS_PROPERTY);
 	return GetNetworkPropertyByOffset<int>(offset);
 }
 
-void PlayerWrapper::SetPlayerClass(int value)
+void PlayerMixin::SetPlayerClass(int value)
 {
 	static int offset = FindNetworkPropertyOffset(PLAYER_CLASS_PROPERTY);
 	SetNetworkPropertyByOffset<int>(offset, value);
 }
 
 
-int PlayerWrapper::GetPlayerState()
+int PlayerMixin::GetPlayerState()
 {
 	static int offset = FindNetworkPropertyOffset("m_iPlayerState");
 	return GetNetworkPropertyByOffset<int>(offset);
 }
 
-void PlayerWrapper::SetPlayerState(int value)
+void PlayerMixin::SetPlayerState(int value)
 {
 	static int offset = FindNetworkPropertyOffset("m_iPlayerState");
 	SetNetworkPropertyByOffset<int>(offset, value);
 }
 
 
-int PlayerWrapper::GetRagdoll()
+int PlayerMixin::GetRagdoll()
 {
 	static int offset = FindNetworkPropertyOffset("m_hRagdoll");
 	return GetNetworkPropertyByOffset<int>(offset);
 }
 
-void PlayerWrapper::SetRagdoll(int value)
+void PlayerMixin::SetRagdoll(int value)
 {
 	static int offset = FindNetworkPropertyOffset("m_hRagdoll");
 	SetNetworkPropertyByOffset<int>(offset, value);
 }
 
 
-int PlayerWrapper::GetActiveDevices()
+int PlayerMixin::GetActiveDevices()
 {
 	static int offset = FindNetworkPropertyOffset("m_HL2Local.m_bitsActiveDevices");
 	return GetNetworkPropertyByOffset<int>(offset);
 }
 
-void PlayerWrapper::SetActiveDevices(int value)
+void PlayerMixin::SetActiveDevices(int value)
 {
 	static int offset = FindNetworkPropertyOffset("m_HL2Local.m_bitsActiveDevices");
 	SetNetworkPropertyByOffset<int>(offset, value);
 }
 
 
-float PlayerWrapper::GetSuitPowerLoad()
+float PlayerMixin::GetSuitPowerLoad()
 {
 	static int offset = FindNetworkPropertyOffset("m_flSuitPowerLoad");
 	return GetNetworkPropertyByOffset<float>(offset);
 }
 
-void PlayerWrapper::SetSuitPowerLoad(float value)
+void PlayerMixin::SetSuitPowerLoad(float value)
 {
 	static int offset = FindNetworkPropertyOffset("m_flSuitPowerLoad");
 	SetNetworkPropertyByOffset<float>(offset, value);
 }
 
 
-int PlayerWrapper::GetDesiredPlayerClass()
+int PlayerMixin::GetDesiredPlayerClass()
 {
 	static int offset = FindNetworkPropertyOffset("m_Shared.m_iDesiredPlayerClass");
 	return GetNetworkPropertyByOffset<int>(offset);
 }
 
-void PlayerWrapper::SetDesiredPlayerClass(int value)
+void PlayerMixin::SetDesiredPlayerClass(int value)
 {
 	static int offset = FindNetworkPropertyOffset("m_Shared.m_iDesiredPlayerClass");
 	SetNetworkPropertyByOffset<int>(offset, value);

--- a/src/core/modules/players/players_entity.cpp
+++ b/src/core/modules/players/players_entity.cpp
@@ -440,3 +440,263 @@ void PlayerWrapper::SetViewAngle(QAngle& value)
 {
 	BOOST_RAISE_EXCEPTION(PyExc_NotImplementedError, "Setting view_angle is not implemented.");
 }
+
+
+float PlayerWrapper::GetStamina()
+{
+	static int offset = FindNetworkPropertyOffset("cslocaldata.m_flStamina");
+	return GetNetworkPropertyByOffset<float>(offset);
+}
+
+void PlayerWrapper::SetStamina(float value)
+{
+	static int offset = FindNetworkPropertyOffset("cslocaldata.m_flStamina");
+	SetNetworkPropertyByOffset<float>(offset, value);
+}
+
+
+int PlayerWrapper::GetShotsFired()
+{
+	static int offset = FindNetworkPropertyOffset("cslocaldata.m_iShotsFired");
+	return GetNetworkPropertyByOffset<float>(offset);
+}
+
+void PlayerWrapper::SetShotsFired(int value)
+{
+	static int offset = FindNetworkPropertyOffset("cslocaldata.m_iShotsFired");
+	SetNetworkPropertyByOffset<float>(offset, value);
+}
+
+
+int PlayerWrapper::GetArmor()
+{
+	static int offset = FindNetworkPropertyOffset("m_ArmorValue");
+	return GetNetworkPropertyByOffset<int>(offset);
+}
+
+void PlayerWrapper::SetArmor(int value)
+{
+	static int offset = FindNetworkPropertyOffset("m_ArmorValue");
+	SetNetworkPropertyByOffset<int>(offset, value);
+}
+
+
+bool PlayerWrapper::GetHasDefuser()
+{
+	static int offset = FindNetworkPropertyOffset("m_bHasDefuser");
+	return GetNetworkPropertyByOffset<bool>(offset);
+}
+
+void PlayerWrapper::SetHasDefuser(bool value)
+{
+	static int offset = FindNetworkPropertyOffset("m_bHasDefuser");
+	SetNetworkPropertyByOffset<bool>(offset, value);
+}
+
+
+bool PlayerWrapper::GetHasHelmet()
+{
+	static int offset = FindNetworkPropertyOffset("m_bHasHelmet");
+	return GetNetworkPropertyByOffset<bool>(offset);
+}
+
+void PlayerWrapper::SetHasHelmet(bool value)
+{
+	static int offset = FindNetworkPropertyOffset("m_bHasHelmet");
+	SetNetworkPropertyByOffset<bool>(offset, value);
+}
+
+
+bool PlayerWrapper::GetHasNightvision()
+{
+	static int offset = FindNetworkPropertyOffset("m_bHasNightVision");
+	return GetNetworkPropertyByOffset<bool>(offset);
+}
+
+void PlayerWrapper::SetHasNightvision(bool value)
+{
+	static int offset = FindNetworkPropertyOffset("m_bHasNightVision");
+	SetNetworkPropertyByOffset<bool>(offset, value);
+}
+
+
+bool PlayerWrapper::GetIsInBombZone()
+{
+	static int offset = FindNetworkPropertyOffset("m_bInBombZone");
+	return GetNetworkPropertyByOffset<bool>(offset);
+}
+
+void PlayerWrapper::SetIsInBombZone(bool value)
+{
+	static int offset = FindNetworkPropertyOffset("m_bInBombZone");
+	SetNetworkPropertyByOffset<bool>(offset, value);
+}
+
+
+bool PlayerWrapper::GetIsInBuyZone()
+{
+	static int offset = FindNetworkPropertyOffset("m_bInBuyZone");
+	return GetNetworkPropertyByOffset<bool>(offset);
+}
+
+void PlayerWrapper::SetIsInBuyZone(bool value)
+{
+	static int offset = FindNetworkPropertyOffset("m_bInBuyZone");
+	SetNetworkPropertyByOffset<bool>(offset, value);
+}
+
+
+bool PlayerWrapper::GetIsInHostageRescueZone()
+{
+	static int offset = FindNetworkPropertyOffset("m_bInHostageRescueZone");
+	return GetNetworkPropertyByOffset<bool>(offset);
+}
+
+void PlayerWrapper::SetIsInHostageRescueZone(bool value)
+{
+	static int offset = FindNetworkPropertyOffset("m_bInHostageRescueZone");
+	SetNetworkPropertyByOffset<bool>(offset, value);
+}
+
+
+bool PlayerWrapper::GetIsDefusing()
+{
+	static int offset = FindNetworkPropertyOffset("m_bIsDefusing");
+	return GetNetworkPropertyByOffset<bool>(offset);
+}
+
+void PlayerWrapper::SetIsDefusing(bool value)
+{
+	static int offset = FindNetworkPropertyOffset("m_bIsDefusing");
+	SetNetworkPropertyByOffset<bool>(offset, value);
+}
+
+
+bool PlayerWrapper::GetNightvisionOn()
+{
+	static int offset = FindNetworkPropertyOffset("m_bNightVisionOn");
+	return GetNetworkPropertyByOffset<bool>(offset);
+}
+
+void PlayerWrapper::SetNightvisionOn(bool value)
+{
+	static int offset = FindNetworkPropertyOffset("m_bNightVisionOn");
+	SetNetworkPropertyByOffset<bool>(offset, value);
+}
+
+
+float PlayerWrapper::GetFlashDuration()
+{
+	static int offset = FindNetworkPropertyOffset("m_flFlashDuration");
+	return GetNetworkPropertyByOffset<float>(offset);
+}
+
+void PlayerWrapper::SetFlashDuration(float value)
+{
+	static int offset = FindNetworkPropertyOffset("m_flFlashDuration");
+	SetNetworkPropertyByOffset<float>(offset, value);
+}
+
+
+float PlayerWrapper::GetFlashAlpha()
+{
+	static int offset = FindNetworkPropertyOffset("m_flFlashMaxAlpha");
+	return GetNetworkPropertyByOffset<float>(offset);
+}
+
+void PlayerWrapper::SetFlashAlpha(float value)
+{
+	static int offset = FindNetworkPropertyOffset("m_flFlashMaxAlpha");
+	SetNetworkPropertyByOffset<float>(offset, value);
+}
+
+
+int PlayerWrapper::GetCash()
+{
+	static int offset = FindNetworkPropertyOffset("m_iAccount");
+	return GetNetworkPropertyByOffset<int>(offset);
+}
+
+void PlayerWrapper::SetCash(int value)
+{
+	static int offset = FindNetworkPropertyOffset("m_iAccount");
+	SetNetworkPropertyByOffset<int>(offset, value);
+}
+
+
+int PlayerWrapper::GetPlayerClass()
+{
+	static int offset = FindNetworkPropertyOffset(PLAYER_CLASS_PROPERTY);
+	return GetNetworkPropertyByOffset<int>(offset);
+}
+
+void PlayerWrapper::SetPlayerClass(int value)
+{
+	static int offset = FindNetworkPropertyOffset(PLAYER_CLASS_PROPERTY);
+	SetNetworkPropertyByOffset<int>(offset, value);
+}
+
+
+int PlayerWrapper::GetPlayerState()
+{
+	static int offset = FindNetworkPropertyOffset("m_iPlayerState");
+	return GetNetworkPropertyByOffset<int>(offset);
+}
+
+void PlayerWrapper::SetPlayerState(int value)
+{
+	static int offset = FindNetworkPropertyOffset("m_iPlayerState");
+	SetNetworkPropertyByOffset<int>(offset, value);
+}
+
+
+int PlayerWrapper::GetRagdoll()
+{
+	static int offset = FindNetworkPropertyOffset("m_hRagdoll");
+	return GetNetworkPropertyByOffset<int>(offset);
+}
+
+void PlayerWrapper::SetRagdoll(int value)
+{
+	static int offset = FindNetworkPropertyOffset("m_hRagdoll");
+	SetNetworkPropertyByOffset<int>(offset, value);
+}
+
+
+int PlayerWrapper::GetActiveDevices()
+{
+	static int offset = FindNetworkPropertyOffset("m_HL2Local.m_bitsActiveDevices");
+	return GetNetworkPropertyByOffset<int>(offset);
+}
+
+void PlayerWrapper::SetActiveDevices(int value)
+{
+	static int offset = FindNetworkPropertyOffset("m_HL2Local.m_bitsActiveDevices");
+	SetNetworkPropertyByOffset<int>(offset, value);
+}
+
+
+float PlayerWrapper::GetSuitPowerLoad()
+{
+	static int offset = FindNetworkPropertyOffset("m_flSuitPowerLoad");
+	return GetNetworkPropertyByOffset<float>(offset);
+}
+
+void PlayerWrapper::SetSuitPowerLoad(float value)
+{
+	static int offset = FindNetworkPropertyOffset("m_flSuitPowerLoad");
+	SetNetworkPropertyByOffset<float>(offset, value);
+}
+
+
+int PlayerWrapper::GetDesiredPlayerClass()
+{
+	static int offset = FindNetworkPropertyOffset("m_Shared.m_iDesiredPlayerClass");
+	return GetNetworkPropertyByOffset<int>(offset);
+}
+
+void PlayerWrapper::SetDesiredPlayerClass(int value)
+{
+	static int offset = FindNetworkPropertyOffset("m_Shared.m_iDesiredPlayerClass");
+	SetNetworkPropertyByOffset<int>(offset, value);
+}

--- a/src/core/modules/players/players_entity.cpp
+++ b/src/core/modules/players/players_entity.cpp
@@ -392,9 +392,10 @@ QAngle PlayerWrapper::GetEyeAngle()
 {
 	static int offset_x = FindNetworkPropertyOffset(EYE_ANGLE_PROPERTY(0));
 	static int offset_y = FindNetworkPropertyOffset(EYE_ANGLE_PROPERTY(1));
-	float x =  GetNetworkPropertyByOffset<float>(offset_x);
-	float y =  GetNetworkPropertyByOffset<float>(offset_y);
-	return QAngle(x, y, 0);
+	return QAngle(
+		GetNetworkPropertyByOffset<float>(offset_x),
+		GetNetworkPropertyByOffset<float>(offset_y),
+		0);
 }
 
 void PlayerWrapper::SetEyeAngle(QAngle& value)
@@ -423,4 +424,19 @@ Vector PlayerWrapper::GetViewVector()
 void PlayerWrapper::SetViewVector(Vector& value)
 {
 	BOOST_RAISE_EXCEPTION(PyExc_NotImplementedError, "Setting view_vector is not implemented.");
+}
+
+
+QAngle PlayerWrapper::GetViewAngle()
+{
+	QAngle eye_angle = GetEyeAngle();
+	return QAngle(
+		eye_angle.x,
+		eye_angle.y < 0 ? eye_angle.y + 360 : eye_angle.y,
+		GetRotation().z);
+}
+
+void PlayerWrapper::SetViewAngle(QAngle& value)
+{
+	BOOST_RAISE_EXCEPTION(PyExc_NotImplementedError, "Setting view_angle is not implemented.");
 }

--- a/src/core/modules/players/players_entity.cpp
+++ b/src/core/modules/players/players_entity.cpp
@@ -61,7 +61,7 @@ float PlayerWrapper::GetSpeed()
 
 void PlayerWrapper::SetSpeed(float value)
 {
-	static int offset = FindNetworkPropertyOffset("m_Local.m_bDucked");
+	static int offset = FindNetworkPropertyOffset("localdata.m_flLaggedMovementValue");
 	SetNetworkPropertyByOffset<float>(offset, value);
 }
 

--- a/src/core/modules/players/players_entity.cpp
+++ b/src/core/modules/players/players_entity.cpp
@@ -386,3 +386,41 @@ void PlayerWrapper::SetPhysDamageScale(float value)
 {
 	SetKeyValue("physdamagescale", value);
 }
+
+
+QAngle PlayerWrapper::GetEyeAngle()
+{
+	static int offset_x = FindNetworkPropertyOffset(EYE_ANGLE_PROPERTY(0));
+	static int offset_y = FindNetworkPropertyOffset(EYE_ANGLE_PROPERTY(1));
+	float x =  GetNetworkPropertyByOffset<float>(offset_x);
+	float y =  GetNetworkPropertyByOffset<float>(offset_y);
+	return QAngle(x, y, 0);
+}
+
+void PlayerWrapper::SetEyeAngle(QAngle& value)
+{
+	static int offset_x = FindNetworkPropertyOffset(EYE_ANGLE_PROPERTY(0));
+	static int offset_y = FindNetworkPropertyOffset(EYE_ANGLE_PROPERTY(1));
+	SetNetworkPropertyByOffset<float>(offset_x, value.x);
+	SetNetworkPropertyByOffset<float>(offset_y, value.y);
+}
+
+
+Vector PlayerWrapper::GetViewVector()
+{
+	QAngle eye_angle = GetEyeAngle();
+
+	float yaw = DEG2RAD(eye_angle.y);
+	float pitch = DEG2RAD(eye_angle.x);
+
+	float sy, cy, sp, cp;
+	SinCos(yaw, &sy, &cy);
+	SinCos(pitch, &sp, &cp);
+
+	return Vector(cp * cy, cp * sy, -sp);
+}
+
+void PlayerWrapper::SetViewVector(Vector& value)
+{
+	BOOST_RAISE_EXCEPTION(PyExc_NotImplementedError, "Setting view_vector is not implemented.");
+}

--- a/src/core/modules/players/players_entity.cpp
+++ b/src/core/modules/players/players_entity.cpp
@@ -1,0 +1,388 @@
+/**
+* =============================================================================
+* Source Python
+* Copyright (C) 2012-2016 Source Python Development Team.  All rights reserved.
+* =============================================================================
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU General Public License, version 3.0, as published by the
+* Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+* details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+* As a special exception, the Source Python Team gives you permission
+* to link the code of this program (as well as its derivative works) to
+* "Half-Life 2," the "Source Engine," and any Game MODs that run on software
+* by the Valve Corporation.  You must obey the GNU General Public License in
+* all respects for all other code used.  Additionally, the Source.Python
+* Development Team grants this exception to all derivative works.
+*/
+
+// ============================================================================
+// >> INCLUDES
+// ============================================================================
+// Source.Python
+#include "players_entity.h"
+
+
+// ============================================================================
+// >> PlayerWrapper
+// ============================================================================
+boost::shared_ptr<PlayerWrapper> PlayerWrapper::__init__(unsigned int uiEntityIndex)
+{
+	CBaseEntityWrapper* pEntity = (CBaseEntityWrapper*) ExcBaseEntityFromIndex(uiEntityIndex);
+	if (!pEntity->IsPlayer())
+		BOOST_RAISE_EXCEPTION(PyExc_ValueError, "Index '%d' is not a valid player.");
+
+	return PlayerWrapper::wrap(pEntity->GetBaseEntity());
+}
+
+boost::shared_ptr<PlayerWrapper> PlayerWrapper::wrap(CBaseEntity* pEntity)
+{
+	return boost::shared_ptr<PlayerWrapper>(
+		(PlayerWrapper *) pEntity,
+		&NeverDeleteDeleter<PlayerWrapper *>
+	);
+}
+
+
+// CBasePlayer
+float PlayerWrapper::GetSpeed()
+{
+	static int offset = FindNetworkPropertyOffset("localdata.m_flLaggedMovementValue");
+	return GetNetworkPropertyByOffset<float>(offset);
+}
+
+void PlayerWrapper::SetSpeed(float value)
+{
+	static int offset = FindNetworkPropertyOffset("m_Local.m_bDucked");
+	SetNetworkPropertyByOffset<float>(offset, value);
+}
+
+
+bool PlayerWrapper::GetIsDucked()
+{
+	static int offset = FindDatamapPropertyOffset("m_Local.m_bDucked");
+	return GetDatamapPropertyByOffset<bool>(offset);
+}
+
+void PlayerWrapper::SetIsDucked(bool value)
+{
+	static int offset = FindDatamapPropertyOffset("m_Local.m_bDucked");
+	SetDatamapPropertyByOffset<bool>(offset, value);
+}
+
+
+bool PlayerWrapper::GetIsDucking()
+{
+	static int offset = FindDatamapPropertyOffset("m_Local.m_bDucking");
+	return GetDatamapPropertyByOffset<bool>(offset);
+}
+
+void PlayerWrapper::SetIsDucking(bool value)
+{
+	static int offset = FindDatamapPropertyOffset("m_Local.m_bDucking");
+	SetDatamapPropertyByOffset<bool>(offset, value);
+}
+
+
+int PlayerWrapper::GetFlags()
+{
+	static int offset = FindNetworkPropertyOffset("m_fFlags");
+	return GetNetworkPropertyByOffset<int>(offset);
+}
+
+void PlayerWrapper::SetFlags(int value)
+{
+	static int offset = FindNetworkPropertyOffset("m_fFlags");
+	SetNetworkPropertyByOffset<int>(offset, value);
+}
+
+
+int PlayerWrapper::GetLastWeapon()
+{
+	static int offset = FindNetworkPropertyOffset("localdata.m_hLastWeapon");
+	return GetNetworkPropertyByOffset<int>(offset);
+}
+
+void PlayerWrapper::SetLastWeapon(int value)
+{
+	static int offset = FindNetworkPropertyOffset("localdata.m_hLastWeapon");
+	SetNetworkPropertyByOffset<int>(offset, value);
+}
+
+
+int PlayerWrapper::GetObserverTarget()
+{
+	static int offset = FindNetworkPropertyOffset("m_hObserverTarget");
+	return GetNetworkPropertyByOffset<int>(offset);
+}
+
+void PlayerWrapper::SetObserverTarget(int value)
+{
+	static int offset = FindNetworkPropertyOffset("m_hObserverTarget");
+	SetNetworkPropertyByOffset<int>(offset, value);
+}
+
+
+int PlayerWrapper::GetDeaths()
+{
+	static int offset = FindDatamapPropertyOffset("m_iDeaths");
+	return GetDatamapPropertyByOffset<int>(offset);
+}
+
+void PlayerWrapper::SetDeaths(int value)
+{
+	static int offset = FindDatamapPropertyOffset("m_iDeaths");
+	SetDatamapPropertyByOffset<int>(offset, value);
+}
+
+
+int PlayerWrapper::GetKills()
+{
+	static int offset = FindDatamapPropertyOffset("m_iFrags");
+	return GetDatamapPropertyByOffset<int>(offset);
+}
+
+void PlayerWrapper::SetKills(int value)
+{
+	static int offset = FindDatamapPropertyOffset("m_iFrags");
+	SetDatamapPropertyByOffset<int>(offset, value);
+}
+
+
+int PlayerWrapper::GetObserverMode()
+{
+	static int offset = FindNetworkPropertyOffset("m_iObserverMode");
+	return GetNetworkPropertyByOffset<int>(offset);
+}
+
+void PlayerWrapper::SetObserverMode(int value)
+{
+	static int offset = FindNetworkPropertyOffset("m_iObserverMode");
+	SetNetworkPropertyByOffset<int>(offset, value);
+}
+
+
+int PlayerWrapper::GetLifeState()
+{
+	static int offset = FindNetworkPropertyOffset("m_lifeState");
+	return GetNetworkPropertyByOffset<int>(offset);
+}
+
+void PlayerWrapper::SetLifeState(int value)
+{
+	static int offset = FindNetworkPropertyOffset("m_lifeState");
+	SetNetworkPropertyByOffset<int>(offset, value);
+}
+
+
+str PlayerWrapper::GetPlace()
+{
+	static int offset = FindNetworkPropertyOffset("m_szLastPlaceName");
+	return str(GetNetworkPropertyStringArrayByOffset(offset));
+}
+
+void PlayerWrapper::SetPlace(const char* value)
+{
+	static int offset = FindNetworkPropertyOffset("m_szLastPlaceName");
+	SetNetworkPropertyStringArrayByOffset(offset, value);
+}
+
+
+bool PlayerWrapper::GetDead()
+{
+	static int offset = FindNetworkPropertyOffset("pl.deadflag");
+	return GetNetworkPropertyByOffset<bool>(offset);
+}
+
+void PlayerWrapper::SetDead(bool value)
+{
+	static int offset = FindNetworkPropertyOffset("pl.deadflag");
+	SetNetworkPropertyByOffset<bool>(offset, value);
+}
+
+
+float PlayerWrapper::GetFallVelocity()
+{
+	static int offset = FindDatamapPropertyOffset("m_Local.m_flFallVelocity");
+	return GetDatamapPropertyByOffset<float>(offset);
+}
+
+void PlayerWrapper::SetFallVelocity(float value)
+{
+	static int offset = FindDatamapPropertyOffset("m_Local.m_flFallVelocity");
+	SetDatamapPropertyByOffset<float>(offset, value);
+}
+
+
+int PlayerWrapper::GetButtons()
+{
+	static int offset = FindDatamapPropertyOffset("m_nButtons");
+	return GetDatamapPropertyByOffset<int>(offset);
+}
+
+void PlayerWrapper::SetButtons(int value)
+{
+	static int offset = FindDatamapPropertyOffset("m_nButtons");
+	SetDatamapPropertyByOffset<int>(offset, value);
+}
+
+
+int PlayerWrapper::GetHiddenHUDs()
+{
+	static int offset = FindDatamapPropertyOffset("m_Local.m_iHideHUD");
+	return GetDatamapPropertyByOffset<int>(offset);
+}
+
+void PlayerWrapper::SetHiddenHUDs(int value)
+{
+	static int offset = FindDatamapPropertyOffset("m_Local.m_iHideHUD");
+	SetDatamapPropertyByOffset<int>(offset, value);
+}
+
+
+int PlayerWrapper::GetDrawViewModel()
+{
+	static int offset = FindDatamapPropertyOffset("m_Local.m_bDrawViewmodel");
+	return GetDatamapPropertyByOffset<int>(offset);
+}
+
+void PlayerWrapper::SetDrawViewModel(int value)
+{
+	static int offset = FindDatamapPropertyOffset("m_Local.m_bDrawViewmodel");
+	SetDatamapPropertyByOffset<int>(offset, value);
+}
+
+
+int PlayerWrapper::GetFOV()
+{
+	static int offset = FindNetworkPropertyOffset("m_iFOV");
+	return GetNetworkPropertyByOffset<int>(offset);
+}
+
+void PlayerWrapper::SetFOV(int value)
+{
+	static int offset = FindNetworkPropertyOffset("m_iFOV");
+	SetNetworkPropertyByOffset<int>(offset, value);
+}
+
+
+int PlayerWrapper::GetFOVStart()
+{
+	static int offset = FindNetworkPropertyOffset("m_iFOVStart");
+	return GetNetworkPropertyByOffset<int>(offset);
+}
+
+void PlayerWrapper::SetFOVStart(int value)
+{
+	static int offset = FindNetworkPropertyOffset("m_iFOVStart");
+	SetNetworkPropertyByOffset<int>(offset, value);
+}
+
+
+float PlayerWrapper::GetFOVTime()
+{
+	static int offset = FindNetworkPropertyOffset("m_flFOVTime");
+	return GetNetworkPropertyByOffset<float>(offset);
+}
+
+void PlayerWrapper::SetFOVTime(float value)
+{
+	static int offset = FindNetworkPropertyOffset("m_flFOVTime");
+	SetNetworkPropertyByOffset<float>(offset, value);
+}
+
+
+int PlayerWrapper::GetDefaultFOV()
+{
+	static int offset = FindNetworkPropertyOffset("m_iDefaultFOV");
+	return GetNetworkPropertyByOffset<int>(offset);
+}
+
+void PlayerWrapper::SetDefaultFOV(int value)
+{
+	static int offset = FindNetworkPropertyOffset("m_iDefaultFOV");
+	SetNetworkPropertyByOffset<int>(offset, value);
+}
+
+
+float PlayerWrapper::GetFOVRate()
+{
+	static int offset = FindDatamapPropertyOffset("m_Local.m_flFOVRate");
+	return GetDatamapPropertyByOffset<float>(offset);
+}
+
+void PlayerWrapper::SetFOVRate(float value)
+{
+	static int offset = FindDatamapPropertyOffset("m_Local.m_flFOVRate");
+	SetDatamapPropertyByOffset<float>(offset, value);
+}
+
+
+// CBaseCombatCharacter
+Vector PlayerWrapper::GetGunOffset()
+{
+	static int offset = FindDatamapPropertyOffset("m_HackedGunPos");
+	return GetDatamapPropertyByOffset<Vector>(offset);
+}
+
+void PlayerWrapper::SetGunOffset(Vector& value)
+{
+	static int offset = FindDatamapPropertyOffset("m_HackedGunPos");
+	SetDatamapPropertyByOffset<Vector>(offset, value);
+}
+
+
+int PlayerWrapper::GetLastHitgroup()
+{
+	static int offset = FindDatamapPropertyOffset("m_LastHitGroup");
+	return GetDatamapPropertyByOffset<int>(offset);
+}
+
+void PlayerWrapper::SetLastHitgroup(int value)
+{
+	static int offset = FindDatamapPropertyOffset("m_LastHitGroup");
+	SetDatamapPropertyByOffset<int>(offset, value);
+}
+
+
+int PlayerWrapper::GetActiveWeaponHandle()
+{
+	static int offset = FindNetworkPropertyOffset("m_hActiveWeapon");
+	return GetNetworkPropertyByOffset<int>(offset);
+}
+
+void PlayerWrapper::SetActiveWeaponHandle(int value)
+{
+	static int offset = FindNetworkPropertyOffset("m_hActiveWeapon");
+	SetNetworkPropertyByOffset<int>(offset, value);
+}
+
+
+str PlayerWrapper::GetRelationship()
+{
+	return GetKeyValueString("Relationship");
+}
+
+void PlayerWrapper::SetRelationship(const char* value)
+{
+	SetKeyValue("Relationship", value);
+}
+
+
+float PlayerWrapper::GetPhysDamageScale()
+{
+	return GetKeyValueFloat("physdamagescale");
+}
+
+void PlayerWrapper::SetPhysDamageScale(float value)
+{
+	SetKeyValue("physdamagescale", value);
+}

--- a/src/core/modules/players/players_entity.h
+++ b/src/core/modules/players/players_entity.h
@@ -39,6 +39,7 @@ using namespace boost::python;
 //-----------------------------------------------------------------------------
 // MACROS
 //-----------------------------------------------------------------------------
+// Eye angle property
 #if defined(ENGINE_BRANCH_TF2)
 	#define EYE_ANGLE_PROPERTY(index) "tfnonlocaldata.m_angEyeAngles[" #index "]"
 #elif defined(ENGINE_BRANCH_BMS)
@@ -47,6 +48,13 @@ using namespace boost::python;
 	#define EYE_ANGLE_PROPERTY(index) "hl2mplocaldata.m_angEyeAngles[" #index "]"
 #else 
 	#define EYE_ANGLE_PROPERTY(index) "m_angEyeAngles[" #index "]"
+#endif
+
+// Player class property
+#if defined(ENGINE_BRANCH_TF2)
+	#define PLAYER_CLASS_PROPERTY "m_PlayerClass.m_iClass"
+#else
+	#define PLAYER_CLASS_PROPERTY "m_iClass"
 #endif
 
 
@@ -151,6 +159,71 @@ public:
 
 	QAngle GetViewAngle();
 	void SetViewAngle(QAngle& value);
+
+	// Game specific
+	// CS:S, CS:GO
+	float GetStamina();
+	void SetStamina(float value);
+
+	int GetShotsFired();
+	void SetShotsFired(int value);
+
+	int GetArmor();
+	void SetArmor(int value);
+
+	bool GetHasDefuser();
+	void SetHasDefuser(bool value);
+
+	bool GetHasHelmet();
+	void SetHasHelmet(bool value);
+
+	bool GetHasNightvision();
+	void SetHasNightvision(bool value);
+
+	bool GetIsInBombZone();
+	void SetIsInBombZone(bool value);
+
+	bool GetIsInBuyZone();
+	void SetIsInBuyZone(bool value);
+
+	bool GetIsInHostageRescueZone();
+	void SetIsInHostageRescueZone(bool value);
+
+	bool GetIsDefusing();
+	void SetIsDefusing(bool value);
+
+	bool GetNightvisionOn();
+	void SetNightvisionOn(bool value);
+
+	float GetFlashDuration();
+	void SetFlashDuration(float value);
+
+	float GetFlashAlpha();
+	void SetFlashAlpha(float value);
+
+	int GetCash();
+	void SetCash(int value);
+
+	int GetPlayerClass();
+	void SetPlayerClass(int value);
+
+	int GetPlayerState();
+	void SetPlayerState(int value);
+
+	int GetRagdoll();
+	void SetRagdoll(int value);
+
+	// HL2
+	int GetActiveDevices();
+	void SetActiveDevices(int value);
+
+	// HL2
+	float GetSuitPowerLoad();
+	void SetSuitPowerLoad(float value);
+
+	// TF2
+	int GetDesiredPlayerClass();
+	void SetDesiredPlayerClass(int value);
 };
 
 

--- a/src/core/modules/players/players_entity.h
+++ b/src/core/modules/players/players_entity.h
@@ -148,6 +148,9 @@ public:
 
 	Vector GetViewVector();
 	void SetViewVector(Vector& value);
+
+	QAngle GetViewAngle();
+	void SetViewAngle(QAngle& value);
 };
 
 

--- a/src/core/modules/players/players_entity.h
+++ b/src/core/modules/players/players_entity.h
@@ -61,11 +61,11 @@ using namespace boost::python;
 //-----------------------------------------------------------------------------
 // CBaseEntity extension class for players.
 //-----------------------------------------------------------------------------
-class PlayerWrapper: public CBaseEntityWrapper
+class PlayerMixin: public CBaseEntityWrapper
 {
 public:
-	static boost::shared_ptr<PlayerWrapper> __init__(unsigned int uiEntityIndex);
-	static boost::shared_ptr<PlayerWrapper> wrap(CBaseEntity* pEntity);
+	static boost::shared_ptr<PlayerMixin> __init__(unsigned int uiEntityIndex);
+	static boost::shared_ptr<PlayerMixin> wrap(CBaseEntity* pEntity);
 	
 	// CBasePlayer
 	// TODO: Return for some of these the proper entity class instead of a handle/index

--- a/src/core/modules/players/players_entity.h
+++ b/src/core/modules/players/players_entity.h
@@ -36,6 +36,19 @@ using namespace boost::python;
 #include "modules/entities/entities_entity.h"
 
 
+//-----------------------------------------------------------------------------
+// MACROS
+//-----------------------------------------------------------------------------
+#if defined(ENGINE_BRANCH_TF2)
+	#define EYE_ANGLE_PROPERTY(index) "tfnonlocaldata.m_angEyeAngles[" #index "]"
+#elif defined(ENGINE_BRANCH_BMS)
+	#define EYE_ANGLE_PROPERTY(index) "blackmesalocaldata.m_angEyeAngles[" #index "]"
+#elif defined(ENGINE_BRANCH_GMOD)
+	#define EYE_ANGLE_PROPERTY(index) "hl2mplocaldata.m_angEyeAngles[" #index "]"
+#else 
+	#define EYE_ANGLE_PROPERTY(index) "m_angEyeAngles[" #index "]"
+#endif
+
 
 //-----------------------------------------------------------------------------
 // CBaseEntity extension class for players.
@@ -129,6 +142,12 @@ public:
 
 	float GetPhysDamageScale();
 	void SetPhysDamageScale(float value);
+
+	QAngle GetEyeAngle();
+	void SetEyeAngle(QAngle& value);
+
+	Vector GetViewVector();
+	void SetViewVector(Vector& value);
 };
 
 

--- a/src/core/modules/players/players_entity.h
+++ b/src/core/modules/players/players_entity.h
@@ -1,0 +1,135 @@
+/**
+* =============================================================================
+* Source Python
+* Copyright (C) 2012-2015 Source Python Development Team.  All rights reserved.
+* =============================================================================
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU General Public License, version 3.0, as published by the
+* Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+* details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+* As a special exception, the Source Python Team gives you permission
+* to link the code of this program (as well as its derivative works) to
+* "Half-Life 2," the "Source Engine," and any Game MODs that run on software
+* by the Valve Corporation.  You must obey the GNU General Public License in
+* all respects for all other code used.  Additionally, the Source.Python
+* Development Team grants this exception to all derivative works.
+*/
+
+#ifndef _PLAYERS_ENTITY_H
+#define _PLAYERS_ENTITY_H
+
+//-----------------------------------------------------------------------------
+// Includes.
+//-----------------------------------------------------------------------------
+#include "boost/python.hpp"
+using namespace boost::python;
+
+#include "modules/entities/entities_entity.h"
+
+
+
+//-----------------------------------------------------------------------------
+// CBaseEntity extension class for players.
+//-----------------------------------------------------------------------------
+class PlayerWrapper: public CBaseEntityWrapper
+{
+public:
+	static boost::shared_ptr<PlayerWrapper> __init__(unsigned int uiEntityIndex);
+	static boost::shared_ptr<PlayerWrapper> wrap(CBaseEntity* pEntity);
+	
+	// CBasePlayer
+	// TODO: Return for some of these the proper entity class instead of a handle/index
+	// E. g. BaseEntity, Entity, Weapon, Player, etc.
+	float GetSpeed();
+	void SetSpeed(float value);
+
+	bool GetIsDucked();
+	void SetIsDucked(bool value);
+
+	bool GetIsDucking();
+	void SetIsDucking(bool value);
+
+	int GetFlags();
+	void SetFlags(int value);
+
+	int GetLastWeapon();
+	void SetLastWeapon(int value);
+
+	int GetObserverTarget();
+	void SetObserverTarget(int value);
+
+	int GetDeaths();
+	void SetDeaths(int value);
+
+	int GetKills();
+	void SetKills(int value);
+
+	// TODO: Return ObserverMode enum
+	int GetObserverMode();
+	void SetObserverMode(int value);
+
+	// TODO: Return LifeState enum
+	int GetLifeState();
+	void SetLifeState(int value);
+
+	str GetPlace();
+	void SetPlace(const char* value);
+
+	bool GetDead();
+	void SetDead(bool value);
+
+	float GetFallVelocity();
+	void SetFallVelocity(float value);
+
+	int GetButtons();
+	void SetButtons(int value);
+
+	int GetHiddenHUDs();
+	void SetHiddenHUDs(int value);
+
+	int GetDrawViewModel();
+	void SetDrawViewModel(int value);
+
+	int GetFOV();
+	void SetFOV(int value);
+
+	int GetFOVStart();
+	void SetFOVStart(int value);
+
+	float GetFOVTime();
+	void SetFOVTime(float value);
+
+	int GetDefaultFOV();
+	void SetDefaultFOV(int value);
+
+	float GetFOVRate();
+	void SetFOVRate(float value);
+
+	// CBaseCombatCharacter
+	Vector GetGunOffset();
+	void SetGunOffset(Vector& value);
+
+	int GetLastHitgroup();
+	void SetLastHitgroup(int value);
+
+	int GetActiveWeaponHandle();
+	void SetActiveWeaponHandle(int value);
+
+	str GetRelationship();
+	void SetRelationship(const char* value);
+
+	float GetPhysDamageScale();
+	void SetPhysDamageScale(float value);
+};
+
+
+#endif // _PLAYERS_ENTITY_H

--- a/src/core/modules/players/players_wrap.cpp
+++ b/src/core/modules/players/players_wrap.cpp
@@ -353,7 +353,7 @@ void export_user_cmd(scope _players)
 
 void export_player_wrapper(scope _players)
 {
-	class_<PlayerWrapper, bases<CBaseEntityWrapper>, boost::noncopyable> _PlayerWrapper("_Player", no_init);
+	class_<PlayerWrapper, bases<CBaseEntityWrapper>, boost::noncopyable> _PlayerWrapper("PlayerMixin", no_init);
 
 	_PlayerWrapper.def("__init__",
 		make_constructor(
@@ -586,6 +586,7 @@ void export_player_wrapper(scope _players)
 		&PlayerWrapper::GetStamina,
 		&PlayerWrapper::SetStamina,
 		"Get/set the player's stamina.\n\n"
+		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: float");
 
 	_PlayerWrapper.add_property(
@@ -593,6 +594,7 @@ void export_player_wrapper(scope _players)
 		&PlayerWrapper::GetShotsFired,
 		&PlayerWrapper::SetShotsFired,
 		"Get/set the the number of shots fired by the player.\n\n"
+		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: int");
 
 	_PlayerWrapper.add_property(
@@ -600,6 +602,7 @@ void export_player_wrapper(scope _players)
 		&PlayerWrapper::GetArmor,
 		&PlayerWrapper::SetArmor,
 		"Get/set the player's armor.\n\n"
+		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: int");
 
 	_PlayerWrapper.add_property(
@@ -607,6 +610,7 @@ void export_player_wrapper(scope _players)
 		&PlayerWrapper::GetHasDefuser,
 		&PlayerWrapper::SetHasDefuser,
 		"Get/set whether the player has a defuser.\n\n"
+		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: bool");
 
 	_PlayerWrapper.add_property(
@@ -614,6 +618,7 @@ void export_player_wrapper(scope _players)
 		&PlayerWrapper::GetHasHelmet,
 		&PlayerWrapper::SetHasHelmet,
 		"Get/set whether the player has a helmet.\n\n"
+		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: bool");
 
 	_PlayerWrapper.add_property(
@@ -621,6 +626,7 @@ void export_player_wrapper(scope _players)
 		&PlayerWrapper::GetIsInBombZone,
 		&PlayerWrapper::SetIsInBombZone,
 		"Get/set whether the player is in a bomb zone.\n\n"
+		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: bool");
 
 	_PlayerWrapper.add_property(
@@ -628,6 +634,7 @@ void export_player_wrapper(scope _players)
 		&PlayerWrapper::GetIsInBuyZone,
 		&PlayerWrapper::SetIsInBuyZone,
 		"Get/set whether the player is in a buy zone.\n\n"
+		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: bool");
 
 	_PlayerWrapper.add_property(
@@ -635,6 +642,7 @@ void export_player_wrapper(scope _players)
 		&PlayerWrapper::GetIsInHostageRescueZone,
 		&PlayerWrapper::SetIsInHostageRescueZone,
 		"Get/set whether the player is in a hostage rescue zone.\n\n"
+		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: bool");
 
 	_PlayerWrapper.add_property(
@@ -642,6 +650,7 @@ void export_player_wrapper(scope _players)
 		&PlayerWrapper::GetIsDefusing,
 		&PlayerWrapper::SetIsDefusing,
 		"Get/set whether the player is currently defusing the bomb.\n\n"
+		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: bool");
 
 	_PlayerWrapper.add_property(
@@ -649,6 +658,7 @@ void export_player_wrapper(scope _players)
 		&PlayerWrapper::GetNightvisionOn,
 		&PlayerWrapper::SetNightvisionOn,
 		"Get/set whether the player is currently using nightvision.\n\n"
+		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: bool");
 
 	_PlayerWrapper.add_property(
@@ -656,6 +666,7 @@ void export_player_wrapper(scope _players)
 		&PlayerWrapper::GetFlashDuration,
 		&PlayerWrapper::SetFlashDuration,
 		"Get/set the player's flash duration.\n\n"
+		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: int");
 
 	_PlayerWrapper.add_property(
@@ -663,6 +674,7 @@ void export_player_wrapper(scope _players)
 		&PlayerWrapper::GetFlashAlpha,
 		&PlayerWrapper::SetFlashAlpha,
 		"Get/set the player's flash alpha.\n\n"
+		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: int");
 
 	_PlayerWrapper.add_property(
@@ -670,6 +682,7 @@ void export_player_wrapper(scope _players)
 		&PlayerWrapper::GetCash,
 		&PlayerWrapper::SetCash,
 		"Get/set the player's cash.\n\n"
+		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: int");
 
 	_PlayerWrapper.add_property(
@@ -698,6 +711,7 @@ void export_player_wrapper(scope _players)
 		&PlayerWrapper::GetActiveDevices,
 		&PlayerWrapper::SetActiveDevices,
 		"Get/set the player's active devices.\n\n"
+		".. note:: Only available in HL2.\n\n"
 		":rtype: int");
 
 	_PlayerWrapper.add_property(
@@ -705,6 +719,7 @@ void export_player_wrapper(scope _players)
 		&PlayerWrapper::GetSuitPowerLoad,
 		&PlayerWrapper::SetSuitPowerLoad,
 		"Get/set the player's suit power load.\n\n"
+		".. note:: Only available in HL2.\n\n"
 		":rtype: float");
 
 	_PlayerWrapper.add_property(
@@ -712,6 +727,7 @@ void export_player_wrapper(scope _players)
 		&PlayerWrapper::GetDesiredPlayerClass,
 		&PlayerWrapper::SetDesiredPlayerClass,
 		"Get/set the player's desired player class.\n\n"
+		".. note:: Only available in TF2.\n\n"
 		":rtype: int");
 
 	_PlayerWrapper ADD_MEM_TOOLS(PlayerWrapper);

--- a/src/core/modules/players/players_wrap.cpp
+++ b/src/core/modules/players/players_wrap.cpp
@@ -353,382 +353,382 @@ void export_user_cmd(scope _players)
 
 void export_player_wrapper(scope _players)
 {
-	class_<PlayerWrapper, bases<CBaseEntityWrapper>, boost::noncopyable> _PlayerWrapper("PlayerMixin", no_init);
+	class_<PlayerMixin, bases<CBaseEntityWrapper>, boost::noncopyable> _PlayerMixin("PlayerMixin", no_init);
 
-	_PlayerWrapper.def("__init__",
+	_PlayerMixin.def("__init__",
 		make_constructor(
-			&PlayerWrapper::__init__,
+			&PlayerMixin::__init__,
 			default_call_policies(),
 			args("entity_index")
 		)
 	);
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"speed",
-		&PlayerWrapper::GetSpeed,
-		&PlayerWrapper::SetSpeed,
+		&PlayerMixin::GetSpeed,
+		&PlayerMixin::SetSpeed,
 		"Get/set the player's speed.\n\n"
 		":rtype: float");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"is_ducked",
-		&PlayerWrapper::GetIsDucked,
-		&PlayerWrapper::SetIsDucked,
+		&PlayerMixin::GetIsDucked,
+		&PlayerMixin::SetIsDucked,
 		"Return whether the player is ducked.\n\n"
 		":rtype: bool");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"is_ducking",
-		&PlayerWrapper::GetIsDucked,
-		&PlayerWrapper::SetIsDucked,
+		&PlayerMixin::GetIsDucked,
+		&PlayerMixin::SetIsDucked,
 		"Return whether the player is duckeding.\n\n"
 		":rtype: bool");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"flags",
-		&PlayerWrapper::GetFlags,
-		&PlayerWrapper::SetFlags,
+		&PlayerMixin::GetFlags,
+		&PlayerMixin::SetFlags,
 		"Get/set the player's flags.\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"last_weapon",
-		&PlayerWrapper::GetLastWeapon,
-		&PlayerWrapper::SetLastWeapon,
+		&PlayerMixin::GetLastWeapon,
+		&PlayerMixin::SetLastWeapon,
 		"Get/set the player's last weapon.\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"observer_target",
-		&PlayerWrapper::GetObserverTarget,
-		&PlayerWrapper::SetObserverTarget,
+		&PlayerMixin::GetObserverTarget,
+		&PlayerMixin::SetObserverTarget,
 		"Get/set the player's observer target.\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"deaths",
-		&PlayerWrapper::GetDeaths,
-		&PlayerWrapper::SetDeaths,
+		&PlayerMixin::GetDeaths,
+		&PlayerMixin::SetDeaths,
 		"Get/set the player's death count.\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"kills",
-		&PlayerWrapper::GetKills,
-		&PlayerWrapper::SetKills,
+		&PlayerMixin::GetKills,
+		&PlayerMixin::SetKills,
 		"Get/set the player's kill count.\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"observer_mode",
-		&PlayerWrapper::GetObserverMode,
-		&PlayerWrapper::SetObserverMode,
+		&PlayerMixin::GetObserverMode,
+		&PlayerMixin::SetObserverMode,
 		"Get/set the player's observer mode.\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"life_state",
-		&PlayerWrapper::GetLifeState,
-		&PlayerWrapper::SetLifeState,
+		&PlayerMixin::GetLifeState,
+		&PlayerMixin::SetLifeState,
 		"Get/set the player's life state.\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"place",
-		&PlayerWrapper::GetPlace,
-		&PlayerWrapper::SetPlace,
+		&PlayerMixin::GetPlace,
+		&PlayerMixin::SetPlace,
 		"Get/set the player's current place.\n\n"
 		":rtype: str");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"dead",
-		&PlayerWrapper::GetDead,
-		&PlayerWrapper::SetDead,
+		&PlayerMixin::GetDead,
+		&PlayerMixin::SetDead,
 		"Return whether the player is dead.\n\n"
 		":rtype: bool");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"fall_velocity",
-		&PlayerWrapper::GetFallVelocity,
-		&PlayerWrapper::SetFallVelocity,
+		&PlayerMixin::GetFallVelocity,
+		&PlayerMixin::SetFallVelocity,
 		"Get/set the player's fall velocity.\n\n"
 		":rtype: float");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"buttons",
-		&PlayerWrapper::GetButtons,
-		&PlayerWrapper::SetButtons,
+		&PlayerMixin::GetButtons,
+		&PlayerMixin::SetButtons,
 		"Get/set the player's currently pressed buttons.\n\n"
 		":rtype: float");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"hidden_huds",
-		&PlayerWrapper::GetHiddenHUDs,
-		&PlayerWrapper::SetHiddenHUDs,
+		&PlayerMixin::GetHiddenHUDs,
+		&PlayerMixin::SetHiddenHUDs,
 		"Get/set the player's hidden HUDs.\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"draw_view_model",
-		&PlayerWrapper::GetDrawViewModel,
-		&PlayerWrapper::SetDrawViewModel,
+		&PlayerMixin::GetDrawViewModel,
+		&PlayerMixin::SetDrawViewModel,
 		"Get/set the player's draw view model.\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"fov",
-		&PlayerWrapper::GetFOV,
-		&PlayerWrapper::SetFOV,
+		&PlayerMixin::GetFOV,
+		&PlayerMixin::SetFOV,
 		"Get/set the player's field of view (FOV).\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"fov_start",
-		&PlayerWrapper::GetFOVStart,
-		&PlayerWrapper::SetFOVStart,
+		&PlayerMixin::GetFOVStart,
+		&PlayerMixin::SetFOVStart,
 		"Get/set the player's field of view (FOV) start.\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"fov_time",
-		&PlayerWrapper::GetFOVTime,
-		&PlayerWrapper::SetFOVTime,
+		&PlayerMixin::GetFOVTime,
+		&PlayerMixin::SetFOVTime,
 		"Get/set the player's field of view (FOV) time.\n\n"
 		":rtype: float");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"default_fov",
-		&PlayerWrapper::GetDefaultFOV,
-		&PlayerWrapper::SetDefaultFOV,
+		&PlayerMixin::GetDefaultFOV,
+		&PlayerMixin::SetDefaultFOV,
 		"Get/set the player's default field of view (FOV).\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"default_fov",
-		&PlayerWrapper::GetDefaultFOV,
-		&PlayerWrapper::SetDefaultFOV,
+		&PlayerMixin::GetDefaultFOV,
+		&PlayerMixin::SetDefaultFOV,
 		"Get/set the player's default field of view (FOV).\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"fov_rate",
-		&PlayerWrapper::GetFOVRate,
-		&PlayerWrapper::SetFOVRate,
+		&PlayerMixin::GetFOVRate,
+		&PlayerMixin::SetFOVRate,
 		"Get/set the player's field of view (FOV) rate.\n\n"
 		":rtype: float");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"gun_offset",
-		&PlayerWrapper::GetGunOffset,
-		&PlayerWrapper::SetGunOffset,
+		&PlayerMixin::GetGunOffset,
+		&PlayerMixin::SetGunOffset,
 		"Get/set the player's gun offset.\n\n"
 		":rtype: Vector");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"last_hitgroup",
-		&PlayerWrapper::GetLastHitgroup,
-		&PlayerWrapper::SetLastHitgroup,
+		&PlayerMixin::GetLastHitgroup,
+		&PlayerMixin::SetLastHitgroup,
 		"Get/set the player's last hitgroup.\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"active_weapon_handle",
-		&PlayerWrapper::GetLastHitgroup,
-		&PlayerWrapper::SetLastHitgroup,
+		&PlayerMixin::GetLastHitgroup,
+		&PlayerMixin::SetLastHitgroup,
 		"Get/set the player's active weapon_handle.\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"relationship",
-		&PlayerWrapper::GetRelationship,
-		&PlayerWrapper::SetRelationship,
+		&PlayerMixin::GetRelationship,
+		&PlayerMixin::SetRelationship,
 		"Get/set the player's relationship.\n\n"
 		":rtype: str");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"phys_damage_scale",
-		&PlayerWrapper::GetPhysDamageScale,
-		&PlayerWrapper::SetPhysDamageScale,
+		&PlayerMixin::GetPhysDamageScale,
+		&PlayerMixin::SetPhysDamageScale,
 		"Get/set the player's physical damage scale.\n\n"
 		":rtype: float");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"eye_angle",
-		&PlayerWrapper::GetEyeAngle,
-		&PlayerWrapper::SetEyeAngle,
+		&PlayerMixin::GetEyeAngle,
+		&PlayerMixin::SetEyeAngle,
 		"Get/set the player's eye angle.\n\n"
 		":rtype: QAngle");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"view_vector",
-		&PlayerWrapper::GetViewVector,
-		&PlayerWrapper::SetViewVector,
+		&PlayerMixin::GetViewVector,
+		&PlayerMixin::SetViewVector,
 		"Get/set the player's view vector.\n\n"
 		":rtype: Vector");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"view_angle",
-		&PlayerWrapper::GetViewAngle,
-		&PlayerWrapper::SetViewAngle,
+		&PlayerMixin::GetViewAngle,
+		&PlayerMixin::SetViewAngle,
 		"Get/set the player's view angle.\n\n"
 		":rtype: QAngle");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"view_offset",
-		&PlayerWrapper::GetViewOffset,
-		&PlayerWrapper::SetViewOffset,
+		&PlayerMixin::GetViewOffset,
+		&PlayerMixin::SetViewOffset,
 		"Get/set the player's view offset.\n\n"
 		":rtype: Vector");
 
 	// Game specific
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"stamina",
-		&PlayerWrapper::GetStamina,
-		&PlayerWrapper::SetStamina,
+		&PlayerMixin::GetStamina,
+		&PlayerMixin::SetStamina,
 		"Get/set the player's stamina.\n\n"
 		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: float");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"shots_fired",
-		&PlayerWrapper::GetShotsFired,
-		&PlayerWrapper::SetShotsFired,
+		&PlayerMixin::GetShotsFired,
+		&PlayerMixin::SetShotsFired,
 		"Get/set the the number of shots fired by the player.\n\n"
 		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"armor",
-		&PlayerWrapper::GetArmor,
-		&PlayerWrapper::SetArmor,
+		&PlayerMixin::GetArmor,
+		&PlayerMixin::SetArmor,
 		"Get/set the player's armor.\n\n"
 		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"has_defuser",
-		&PlayerWrapper::GetHasDefuser,
-		&PlayerWrapper::SetHasDefuser,
+		&PlayerMixin::GetHasDefuser,
+		&PlayerMixin::SetHasDefuser,
 		"Get/set whether the player has a defuser.\n\n"
 		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: bool");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"has_helmet",
-		&PlayerWrapper::GetHasHelmet,
-		&PlayerWrapper::SetHasHelmet,
+		&PlayerMixin::GetHasHelmet,
+		&PlayerMixin::SetHasHelmet,
 		"Get/set whether the player has a helmet.\n\n"
 		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: bool");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"in_bomb_zone",
-		&PlayerWrapper::GetIsInBombZone,
-		&PlayerWrapper::SetIsInBombZone,
+		&PlayerMixin::GetIsInBombZone,
+		&PlayerMixin::SetIsInBombZone,
 		"Get/set whether the player is in a bomb zone.\n\n"
 		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: bool");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"in_buy_zone",
-		&PlayerWrapper::GetIsInBuyZone,
-		&PlayerWrapper::SetIsInBuyZone,
+		&PlayerMixin::GetIsInBuyZone,
+		&PlayerMixin::SetIsInBuyZone,
 		"Get/set whether the player is in a buy zone.\n\n"
 		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: bool");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"in_rescue_zone",
-		&PlayerWrapper::GetIsInHostageRescueZone,
-		&PlayerWrapper::SetIsInHostageRescueZone,
+		&PlayerMixin::GetIsInHostageRescueZone,
+		&PlayerMixin::SetIsInHostageRescueZone,
 		"Get/set whether the player is in a hostage rescue zone.\n\n"
 		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: bool");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"is_defusing",
-		&PlayerWrapper::GetIsDefusing,
-		&PlayerWrapper::SetIsDefusing,
+		&PlayerMixin::GetIsDefusing,
+		&PlayerMixin::SetIsDefusing,
 		"Get/set whether the player is currently defusing the bomb.\n\n"
 		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: bool");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"nightvision_on",
-		&PlayerWrapper::GetNightvisionOn,
-		&PlayerWrapper::SetNightvisionOn,
+		&PlayerMixin::GetNightvisionOn,
+		&PlayerMixin::SetNightvisionOn,
 		"Get/set whether the player is currently using nightvision.\n\n"
 		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: bool");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"flash_duration",
-		&PlayerWrapper::GetFlashDuration,
-		&PlayerWrapper::SetFlashDuration,
+		&PlayerMixin::GetFlashDuration,
+		&PlayerMixin::SetFlashDuration,
 		"Get/set the player's flash duration.\n\n"
 		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"flash_alpha",
-		&PlayerWrapper::GetFlashAlpha,
-		&PlayerWrapper::SetFlashAlpha,
+		&PlayerMixin::GetFlashAlpha,
+		&PlayerMixin::SetFlashAlpha,
 		"Get/set the player's flash alpha.\n\n"
 		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"cash",
-		&PlayerWrapper::GetCash,
-		&PlayerWrapper::SetCash,
+		&PlayerMixin::GetCash,
+		&PlayerMixin::SetCash,
 		"Get/set the player's cash.\n\n"
 		".. note:: Only available in CS:GO and CS:S.\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"player_class",
-		&PlayerWrapper::GetPlayerClass,
-		&PlayerWrapper::SetPlayerClass,
+		&PlayerMixin::GetPlayerClass,
+		&PlayerMixin::SetPlayerClass,
 		"Get/set the player's player class.\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"player_state",
-		&PlayerWrapper::GetPlayerState,
-		&PlayerWrapper::SetPlayerState,
+		&PlayerMixin::GetPlayerState,
+		&PlayerMixin::SetPlayerState,
 		"Get/set the player's player state.\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"ragdoll",
-		&PlayerWrapper::GetRagdoll,
-		&PlayerWrapper::SetRagdoll,
+		&PlayerMixin::GetRagdoll,
+		&PlayerMixin::SetRagdoll,
 		"Get/set the player's ragdoll.\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"active_devices",
-		&PlayerWrapper::GetActiveDevices,
-		&PlayerWrapper::SetActiveDevices,
+		&PlayerMixin::GetActiveDevices,
+		&PlayerMixin::SetActiveDevices,
 		"Get/set the player's active devices.\n\n"
 		".. note:: Only available in HL2.\n\n"
 		":rtype: int");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"suit_power_load",
-		&PlayerWrapper::GetSuitPowerLoad,
-		&PlayerWrapper::SetSuitPowerLoad,
+		&PlayerMixin::GetSuitPowerLoad,
+		&PlayerMixin::SetSuitPowerLoad,
 		"Get/set the player's suit power load.\n\n"
 		".. note:: Only available in HL2.\n\n"
 		":rtype: float");
 
-	_PlayerWrapper.add_property(
+	_PlayerMixin.add_property(
 		"desired_player_class",
-		&PlayerWrapper::GetDesiredPlayerClass,
-		&PlayerWrapper::SetDesiredPlayerClass,
+		&PlayerMixin::GetDesiredPlayerClass,
+		&PlayerMixin::SetDesiredPlayerClass,
 		"Get/set the player's desired player class.\n\n"
 		".. note:: Only available in TF2.\n\n"
 		":rtype: int");
 
-	_PlayerWrapper ADD_MEM_TOOLS(PlayerWrapper);
+	_PlayerMixin ADD_MEM_TOOLS(PlayerMixin);
 }

--- a/src/core/modules/players/players_wrap.cpp
+++ b/src/core/modules/players/players_wrap.cpp
@@ -566,5 +566,12 @@ void export_player_wrapper(scope _players)
 		"Get/set the player's view vector.\n\n"
 		":rtype: Vector");
 
+	_PlayerWrapper.add_property(
+		"view_angle",
+		&PlayerWrapper::GetViewAngle,
+		&PlayerWrapper::SetViewAngle,
+		"Get/set the player's view angle.\n\n"
+		":rtype: QAngle");
+
 	_PlayerWrapper ADD_MEM_TOOLS(PlayerWrapper);
 }

--- a/src/core/modules/players/players_wrap.cpp
+++ b/src/core/modules/players/players_wrap.cpp
@@ -573,5 +573,146 @@ void export_player_wrapper(scope _players)
 		"Get/set the player's view angle.\n\n"
 		":rtype: QAngle");
 
+	_PlayerWrapper.add_property(
+		"view_offset",
+		&PlayerWrapper::GetViewOffset,
+		&PlayerWrapper::SetViewOffset,
+		"Get/set the player's view offset.\n\n"
+		":rtype: Vector");
+
+	// Game specific
+	_PlayerWrapper.add_property(
+		"stamina",
+		&PlayerWrapper::GetStamina,
+		&PlayerWrapper::SetStamina,
+		"Get/set the player's stamina.\n\n"
+		":rtype: float");
+
+	_PlayerWrapper.add_property(
+		"shots_fired",
+		&PlayerWrapper::GetShotsFired,
+		&PlayerWrapper::SetShotsFired,
+		"Get/set the the number of shots fired by the player.\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"armor",
+		&PlayerWrapper::GetArmor,
+		&PlayerWrapper::SetArmor,
+		"Get/set the player's armor.\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"has_defuser",
+		&PlayerWrapper::GetHasDefuser,
+		&PlayerWrapper::SetHasDefuser,
+		"Get/set whether the player has a defuser.\n\n"
+		":rtype: bool");
+
+	_PlayerWrapper.add_property(
+		"has_helmet",
+		&PlayerWrapper::GetHasHelmet,
+		&PlayerWrapper::SetHasHelmet,
+		"Get/set whether the player has a helmet.\n\n"
+		":rtype: bool");
+
+	_PlayerWrapper.add_property(
+		"in_bomb_zone",
+		&PlayerWrapper::GetIsInBombZone,
+		&PlayerWrapper::SetIsInBombZone,
+		"Get/set whether the player is in a bomb zone.\n\n"
+		":rtype: bool");
+
+	_PlayerWrapper.add_property(
+		"in_buy_zone",
+		&PlayerWrapper::GetIsInBuyZone,
+		&PlayerWrapper::SetIsInBuyZone,
+		"Get/set whether the player is in a buy zone.\n\n"
+		":rtype: bool");
+
+	_PlayerWrapper.add_property(
+		"in_rescue_zone",
+		&PlayerWrapper::GetIsInHostageRescueZone,
+		&PlayerWrapper::SetIsInHostageRescueZone,
+		"Get/set whether the player is in a hostage rescue zone.\n\n"
+		":rtype: bool");
+
+	_PlayerWrapper.add_property(
+		"is_defusing",
+		&PlayerWrapper::GetIsDefusing,
+		&PlayerWrapper::SetIsDefusing,
+		"Get/set whether the player is currently defusing the bomb.\n\n"
+		":rtype: bool");
+
+	_PlayerWrapper.add_property(
+		"nightvision_on",
+		&PlayerWrapper::GetNightvisionOn,
+		&PlayerWrapper::SetNightvisionOn,
+		"Get/set whether the player is currently using nightvision.\n\n"
+		":rtype: bool");
+
+	_PlayerWrapper.add_property(
+		"flash_duration",
+		&PlayerWrapper::GetFlashDuration,
+		&PlayerWrapper::SetFlashDuration,
+		"Get/set the player's flash duration.\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"flash_alpha",
+		&PlayerWrapper::GetFlashAlpha,
+		&PlayerWrapper::SetFlashAlpha,
+		"Get/set the player's flash alpha.\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"cash",
+		&PlayerWrapper::GetCash,
+		&PlayerWrapper::SetCash,
+		"Get/set the player's cash.\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"player_class",
+		&PlayerWrapper::GetPlayerClass,
+		&PlayerWrapper::SetPlayerClass,
+		"Get/set the player's player class.\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"player_state",
+		&PlayerWrapper::GetPlayerState,
+		&PlayerWrapper::SetPlayerState,
+		"Get/set the player's player state.\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"ragdoll",
+		&PlayerWrapper::GetRagdoll,
+		&PlayerWrapper::SetRagdoll,
+		"Get/set the player's ragdoll.\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"active_devices",
+		&PlayerWrapper::GetActiveDevices,
+		&PlayerWrapper::SetActiveDevices,
+		"Get/set the player's active devices.\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"suit_power_load",
+		&PlayerWrapper::GetSuitPowerLoad,
+		&PlayerWrapper::SetSuitPowerLoad,
+		"Get/set the player's suit power load.\n\n"
+		":rtype: float");
+
+	_PlayerWrapper.add_property(
+		"desired_player_class",
+		&PlayerWrapper::GetDesiredPlayerClass,
+		&PlayerWrapper::SetDesiredPlayerClass,
+		"Get/set the player's desired player class.\n\n"
+		":rtype: int");
+
 	_PlayerWrapper ADD_MEM_TOOLS(PlayerWrapper);
 }

--- a/src/core/modules/players/players_wrap.cpp
+++ b/src/core/modules/players/players_wrap.cpp
@@ -38,6 +38,7 @@
 #include "inetchannelinfo.h"
 #include "inetchannel.h"
 #include "players_wrap.h"
+#include "players_entity.h"
 
 #include ENGINE_INCLUDE_PATH(players_wrap.h)
 
@@ -49,6 +50,7 @@ void export_playerinfo(scope);
 void export_player_generator(scope);
 void export_client(scope);
 void export_user_cmd(scope);
+void export_player_wrapper(scope);
 
 
 //-----------------------------------------------------------------------------
@@ -60,6 +62,7 @@ DECLARE_SP_MODULE(_players)
 	export_player_generator(_players);
 	export_client(_players);
 	export_user_cmd(_players);
+	export_player_wrapper(_players);
 }
 
 
@@ -346,4 +349,208 @@ void export_user_cmd(scope _players)
 	export_engine_specific_user_cmd(_players, UserCmd);
 
 	UserCmd ADD_MEM_TOOLS(CUserCmd);
+}
+
+void export_player_wrapper(scope _players)
+{
+	class_<PlayerWrapper, bases<CBaseEntityWrapper>, boost::noncopyable> _PlayerWrapper("_Player", no_init);
+
+	_PlayerWrapper.def("__init__",
+		make_constructor(
+			&PlayerWrapper::__init__,
+			default_call_policies(),
+			args("entity_index")
+		)
+	);
+
+	_PlayerWrapper.add_property(
+		"speed",
+		&PlayerWrapper::GetSpeed,
+		&PlayerWrapper::SetSpeed,
+		"Get/set the player's speed.\n\n"
+		":rtype: float");
+
+	_PlayerWrapper.add_property(
+		"is_ducked",
+		&PlayerWrapper::GetIsDucked,
+		&PlayerWrapper::SetIsDucked,
+		"Return whether the player is ducked.\n\n"
+		":rtype: bool");
+
+	_PlayerWrapper.add_property(
+		"is_ducking",
+		&PlayerWrapper::GetIsDucked,
+		&PlayerWrapper::SetIsDucked,
+		"Return whether the player is duckeding.\n\n"
+		":rtype: bool");
+
+	_PlayerWrapper.add_property(
+		"flags",
+		&PlayerWrapper::GetFlags,
+		&PlayerWrapper::SetFlags,
+		"Get/set the player's flags.\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"last_weapon",
+		&PlayerWrapper::GetLastWeapon,
+		&PlayerWrapper::SetLastWeapon,
+		"Get/set the player's last weapon.\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"observer_target",
+		&PlayerWrapper::GetObserverTarget,
+		&PlayerWrapper::SetObserverTarget,
+		"Get/set the player's observer target.\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"deaths",
+		&PlayerWrapper::GetDeaths,
+		&PlayerWrapper::SetDeaths,
+		"Get/set the player's death count.\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"kills",
+		&PlayerWrapper::GetKills,
+		&PlayerWrapper::SetKills,
+		"Get/set the player's kill count.\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"observer_mode",
+		&PlayerWrapper::GetObserverMode,
+		&PlayerWrapper::SetObserverMode,
+		"Get/set the player's observer mode.\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"life_state",
+		&PlayerWrapper::GetLifeState,
+		&PlayerWrapper::SetLifeState,
+		"Get/set the player's life state.\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"place",
+		&PlayerWrapper::GetPlace,
+		&PlayerWrapper::SetPlace,
+		"Get/set the player's current place.\n\n"
+		":rtype: str");
+
+	_PlayerWrapper.add_property(
+		"dead",
+		&PlayerWrapper::GetDead,
+		&PlayerWrapper::SetDead,
+		"Return whether the player is dead.\n\n"
+		":rtype: bool");
+
+	_PlayerWrapper.add_property(
+		"fall_velocity",
+		&PlayerWrapper::GetFallVelocity,
+		&PlayerWrapper::SetFallVelocity,
+		"Get/set the player's fall velocity.\n\n"
+		":rtype: float");
+
+	_PlayerWrapper.add_property(
+		"buttons",
+		&PlayerWrapper::GetButtons,
+		&PlayerWrapper::SetButtons,
+		"Get/set the player's currently pressed buttons.\n\n"
+		":rtype: float");
+
+	_PlayerWrapper.add_property(
+		"hidden_huds",
+		&PlayerWrapper::GetHiddenHUDs,
+		&PlayerWrapper::SetHiddenHUDs,
+		"Get/set the player's hidden HUDs.\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"draw_view_model",
+		&PlayerWrapper::GetDrawViewModel,
+		&PlayerWrapper::SetDrawViewModel,
+		"Get/set the player's draw view model.\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"fov",
+		&PlayerWrapper::GetFOV,
+		&PlayerWrapper::SetFOV,
+		"Get/set the player's field of view (FOV).\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"fov_start",
+		&PlayerWrapper::GetFOVStart,
+		&PlayerWrapper::SetFOVStart,
+		"Get/set the player's field of view (FOV) start.\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"fov_time",
+		&PlayerWrapper::GetFOVTime,
+		&PlayerWrapper::SetFOVTime,
+		"Get/set the player's field of view (FOV) time.\n\n"
+		":rtype: float");
+
+	_PlayerWrapper.add_property(
+		"default_fov",
+		&PlayerWrapper::GetDefaultFOV,
+		&PlayerWrapper::SetDefaultFOV,
+		"Get/set the player's default field of view (FOV).\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"default_fov",
+		&PlayerWrapper::GetDefaultFOV,
+		&PlayerWrapper::SetDefaultFOV,
+		"Get/set the player's default field of view (FOV).\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"fov_rate",
+		&PlayerWrapper::GetFOVRate,
+		&PlayerWrapper::SetFOVRate,
+		"Get/set the player's field of view (FOV) rate.\n\n"
+		":rtype: float");
+
+	_PlayerWrapper.add_property(
+		"gun_offset",
+		&PlayerWrapper::GetGunOffset,
+		&PlayerWrapper::SetGunOffset,
+		"Get/set the player's gun offset.\n\n"
+		":rtype: Vector");
+
+	_PlayerWrapper.add_property(
+		"last_hitgroup",
+		&PlayerWrapper::GetLastHitgroup,
+		&PlayerWrapper::SetLastHitgroup,
+		"Get/set the player's last hitgroup.\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"active_weapon_handle",
+		&PlayerWrapper::GetLastHitgroup,
+		&PlayerWrapper::SetLastHitgroup,
+		"Get/set the player's active weapon_handle.\n\n"
+		":rtype: int");
+
+	_PlayerWrapper.add_property(
+		"relationship",
+		&PlayerWrapper::GetRelationship,
+		&PlayerWrapper::SetRelationship,
+		"Get/set the player's relationship.\n\n"
+		":rtype: str");
+
+	_PlayerWrapper.add_property(
+		"phys_damage_scale",
+		&PlayerWrapper::GetPhysDamageScale,
+		&PlayerWrapper::SetPhysDamageScale,
+		"Get/set the player's physical damage scale.\n\n"
+		":rtype: float");
+
+	_PlayerWrapper ADD_MEM_TOOLS(PlayerWrapper);
 }

--- a/src/core/modules/players/players_wrap.cpp
+++ b/src/core/modules/players/players_wrap.cpp
@@ -552,5 +552,19 @@ void export_player_wrapper(scope _players)
 		"Get/set the player's physical damage scale.\n\n"
 		":rtype: float");
 
+	_PlayerWrapper.add_property(
+		"eye_angle",
+		&PlayerWrapper::GetEyeAngle,
+		&PlayerWrapper::SetEyeAngle,
+		"Get/set the player's eye angle.\n\n"
+		":rtype: QAngle");
+
+	_PlayerWrapper.add_property(
+		"view_vector",
+		&PlayerWrapper::GetViewVector,
+		&PlayerWrapper::SetViewVector,
+		"Get/set the player's view vector.\n\n"
+		":rtype: Vector");
+
 	_PlayerWrapper ADD_MEM_TOOLS(PlayerWrapper);
 }


### PR DESCRIPTION
Just like the [Entity changes](https://github.com/Source-Python-Dev-Team/Source.Python/pull/235) last year, but now for the Player class.

This PR removes the properties from the data files that have been added to the BaseEntity class statically, because we don't need them anymore.

The PR also moves all player properties to a class called PlayerMixin. The PlayerMixin class is mixed into the class ``players._base.Player``. This is done to gain major speed improvements (85 - 125 times faster depending on the property). Moreover, these properties are now documented on the wiki.

I have also moved the game specific properties to PlayerMixin. If you access one of those properties in a different game, you will get the following error:
``ValueError: Unable to find property 'm_Shared.m_iDesiredPlayerClass'.``

We could think about catching this exception and re-raising a NotImplementedError or something like that. What's your opinion on this?

Outlook:
- Return the proper entity class for some attributes (e. g. ``observer_target``) instead of returning an index or handle.
- Move more player functions/properties to the mixin class

PS: You need an instance of the Player class to take advantage of the speed improvements. If you use the Entity class, it will still access the data files. That's something I can live with for now.

