### PR TITLE
Added server command post hooks

### DIFF
--- a/src/core/modules/commands/commands_say.cpp
+++ b/src/core/modules/commands/commands_say.cpp
@@ -268,7 +268,7 @@ void SayConCommand::Dispatch( const CCommand& command )
 	SayCommandMap::iterator iter;
 	if (find_manager<SayCommandMap, SayCommandMap::iterator>(g_SayCommandMap, stripped_command[0], iter))
 	{
-		if(iter->second->Dispatch(stripped_command, iIndex, bTeamOnly)  == BLOCK)
+		if(iter->second->Dispatch(stripped_command, iIndex, bTeamOnly) == BLOCK)
 		{
 			// Block the command
 			return;

--- a/src/core/modules/commands/commands_server.h
+++ b/src/core/modules/commands/commands_server.h
@@ -32,6 +32,8 @@
 #include "utlvector.h"
 #include "convar.h"
 
+#include "hook.h"
+
 //-----------------------------------------------------------------------------
 // Server Command Manager class.
 //-----------------------------------------------------------------------------
@@ -42,15 +44,15 @@ public:
 	~CServerCommandManager();
 	virtual void Init();
 
-	void AddCallback(PyObject* pCallable);
-	void RemoveCallback(PyObject* pCallable);
+	void AddCallback(PyObject* pCallable, HookType_t type);
+	void RemoveCallback(PyObject* pCallable, HookType_t type);
 
 protected:
 	void Dispatch( const CCommand& command);
 
 private:
 	CServerCommandManager(ConCommand* pConCommand, const char* szName, const char* szHelpString = 0, int iFlags = 0);
-	CUtlVector<object> m_vecCallables;
+	std::map< HookType_t, CUtlVector<object>* > m_vecCallables;
 	const char* m_Name;
 	ConCommand* m_pOldCommand;
 };

--- a/src/core/modules/commands/commands_server_wrap.cpp
+++ b/src/core/modules/commands/commands_server_wrap.cpp
@@ -82,13 +82,13 @@ void export_server_command_manager(scope _server)
 		.def("add_callback",
 			&CServerCommandManager::AddCallback,
 			"Adds a callback to the server command's list.",
-			args("callable")
+			(arg("callable"), arg("hook_type")=HOOKTYPE_PRE)
 		)
 
 		.def("remove_callback",
 			&CServerCommandManager::RemoveCallback,
 			"Removes a callback from the server command's list.",
-			args("callable")
+			(arg("callable"), arg("hook_type")=HOOKTYPE_PRE)
 		)
 
 		ADD_MEM_TOOLS(CServerCommandManager)


### PR DESCRIPTION
This PR adds the possibility to register server command post hooks by adding a new parameter to ``<ServerCommandDispatcher>.add_callback/remove_callback()``. I didn't update the ``ServerCommand`` decorator class, because it doesn't seem to be that easy. So, if you want to register a server command post hook, you need to use the low-level functions:
```python
from commands.server import get_server_command
from memory.hooks import HookType

echo = get_server_command('echo')

def pre_echo(command):
    print('pre_echo', tuple(command))
    
def post_echo(command):
    print('post_echo', tuple(command))
    
echo.add_callback(pre_echo, HookType.PRE)
echo.add_callback(post_echo, HookType.POST)

def unload():
    echo.remove_callback(pre_echo, HookType.PRE)
    echo.remove_callback(post_echo, HookType.POST)
```
Output:
```
echo Hello World!
pre_echo ('echo', 'Hello', 'World!')
Hello World!
post_echo ('echo', 'Hello', 'World!')
```