### PR TITLE
Pass index instead Player object in the listeners

### DIFF
--- a/addons/source-python/docs/source-python/source/developing/module_tutorials/listeners.rst
+++ b/addons/source-python/docs/source-python/source/developing/module_tutorials/listeners.rst
@@ -339,7 +339,7 @@ Called when the button state of a player changed.
     from listeners import OnButtonStateChanged
 
     @OnButtonStateChanged
-    def on_button_state_changed(player, old_buttons, new_buttons):
+    def on_button_state_changed(index, old_buttons, new_buttons):
         pass
 
 .. seealso::
@@ -358,7 +358,7 @@ Called when a player runs a command.
     from listeners import OnPlayerRunCommand
 
     @OnPlayerRunCommand
-    def on_player_run_command(player, user_cmd):
+    def on_player_run_command(index, user_cmd):
         pass
 
 

--- a/addons/source-python/packages/source-python/listeners/__init__.py
+++ b/addons/source-python/packages/source-python/listeners/__init__.py
@@ -462,10 +462,11 @@ def get_button_combination_status(old_buttons, new_buttons, combination):
     .. code:: python
 
         @OnButtonStateChanged
-        def on_buttons_state_changed(player, old_buttons, new_buttons):
+        def on_buttons_state_changed(index, old_buttons, new_buttons):
             status = get_button_combination_status(old_buttons, new_buttons,
                 PlayerButtons.ATTACK|PlayerButtons.JUMP)
-
+            player = Player(index)
+            
             if status == ButtonStatus.PRESSED:
                 SayText2(
                     '{} is jumping and attacking.'.format(player.name)).send()

--- a/src/core/sp_hooks.cpp
+++ b/src/core/sp_hooks.cpp
@@ -175,7 +175,6 @@ bool PrePlayerRunCommand(HookType_t hook_type, CHook* pHook)
 	if (!run_command_manager->GetCount() && !button_state_manager->GetCount())
 		return false;
 
-	static object Player = import("players.entity").attr("Player");
 
 	CBaseEntity* pEntity = pHook->GetArgument<CBaseEntity*>(0);
 	unsigned int index;
@@ -190,8 +189,7 @@ bool PrePlayerRunCommand(HookType_t hook_type, CHook* pHook)
 	CUserCmd* pCmd = pHook->GetArgument<CUserCmd*>(1);
 #endif
 
-	object player = Player(index);
-	CALL_LISTENERS(OnPlayerRunCommand, player, ptr(pCmd));
+	CALL_LISTENERS(OnPlayerRunCommand, index, ptr(pCmd));
 
 	if (button_state_manager->GetCount())
 	{
@@ -201,7 +199,7 @@ bool PrePlayerRunCommand(HookType_t hook_type, CHook* pHook)
 		int buttons = pWrapper->GetDatamapPropertyByOffset<int>(offset);
 		if (buttons != pCmd->buttons)
 		{
-			CALL_LISTENERS(OnButtonStateChanged, player, buttons, pCmd->buttons);
+			CALL_LISTENERS(OnButtonStateChanged, index, buttons, pCmd->buttons);
 		}
 	}
 	


### PR DESCRIPTION
In most cases full Player object isn't necessary because it only serves to get entity index which passed to PlayerDictionary object to get cached own object.

I'm not sure if the code is correct because I couldn't build SP on Windows properly.