### PR TITLE
Fixed CS:GO mvps and clan_tag offsets.

### DIFF
--- a/addons/source-python/data/source-python/entities/csgo/CCSPlayer.ini
+++ b/addons/source-python/data/source-python/entities/csgo/CCSPlayer.ini
@@ -60,13 +60,13 @@ srv_check = False
 [instance_attribute]
 
     [[mvps]]
-        offset_windows = 12028
-        offset_linux = 12052
+        offset_windows = 12148
+        offset_linux = 12172
         type = INT
 
     [[clan_tag]]
-        offset_windows = 10052
-        offset_linux = 10076
+        offset_windows = 10140
+        offset_linux = 10164
         type = STRING_ARRAY
 
 


### PR DESCRIPTION
Additional fix to #285.

Not tested on Windows.