### PR TITLE
Added entity instances caching.

### DIFF
--- a/addons/source-python/packages/source-python/entities/_base.py
+++ b/addons/source-python/packages/source-python/entities/_base.py
@@ -100,11 +100,11 @@ class EntityCaching(BaseEntity.__class__):
 
         def __new__(self, index):
             # Let's first lookup for a cached instance
-            caching = self in metaclass.cache
-            if caching:
-                cache = metaclass.cache[self]
-                if index in cache:
-                    return cache[index]
+            cache = metaclass.cache.get(self, None)
+            if cache is not None:
+                obj = cache.get(index, None)
+                if obj is not None:
+                    return obj
 
             # Nothing in cache, let's create a new instance
             obj = cls.__base__.__new__(self, index)
@@ -118,7 +118,7 @@ class EntityCaching(BaseEntity.__class__):
                     )
 
             # Let's cache the new instance we just created
-            if caching:
+            if cache is not None:
                 cache[index] = obj
 
             # We are done, let's return the instance

--- a/addons/source-python/packages/source-python/entities/_base.py
+++ b/addons/source-python/packages/source-python/entities/_base.py
@@ -87,10 +87,13 @@ class EntityCaching(BaseEntity.__class__):
         cls = super().__new__(
             metaclass, classname, bases, attributes
         )
+        # No need to override the instance creation/initialisation if we
+        #   are not caching them
+        if not caching:
+            return cls
 
         # New instances of this class will be cached in that dictionary
-        if caching:
-            metaclass.cache[cls] = {}
+        metaclass.cache[cls] = {}
 
         def __init__(self, index):
             # Does nothing, so we don't re-initialize cached instances, etc.

--- a/addons/source-python/packages/source-python/entities/_base.py
+++ b/addons/source-python/packages/source-python/entities/_base.py
@@ -111,7 +111,7 @@ class EntityCaching(BaseEntity.__class__):
 
             # Successively initialize the base classes
             # This is required, because Boost's construction happens there
-            for base in (self,) + bases:
+            for base in dict.fromkeys((self,) + bases + self.__bases__):
                 getattr(
                     base.__init__, '__wrapped__', base.__init__)(
                         obj, index

--- a/addons/source-python/packages/source-python/entities/_base.py
+++ b/addons/source-python/packages/source-python/entities/_base.py
@@ -103,7 +103,7 @@ class _EntityCaching(BaseEntity.__class__):
         """
         # Let's first lookup for a cached instance
         if caching:
-            obj = cls.cache.get(index, None)
+            obj = cls._cache.get(index, None)
             if obj is not None:
                 return obj
 
@@ -112,14 +112,10 @@ class _EntityCaching(BaseEntity.__class__):
 
         # Let's cache the new instance we just created
         if caching:
-            cls.cache[index] = obj
+            cls._cache[index] = obj
 
         # We are done, let's return the instance
         return obj
-
-    @property
-    def cache(self):
-        return self._cache
 
     def _on_entity_deleted(cls, base_entity):
         """Called when an entity is deleted."""
@@ -127,7 +123,7 @@ class _EntityCaching(BaseEntity.__class__):
             return
 
         # Cleanup the cache
-        cls.cache.pop(base_entity.index, None)
+        cls._cache.pop(base_entity.index, None)
 
 
 class Entity(BaseEntity, metaclass=_EntityCaching):
@@ -288,6 +284,14 @@ class Entity(BaseEntity, metaclass=_EntityCaching):
     def _obj(cls, ptr):
         """Return an entity instance of the given pointer."""
         return cls(index_from_pointer(ptr))
+
+    @property
+    def cache(self):
+        """Returns the cached instances of this class.
+
+        :rtype: dict
+        """
+        return self._cache
 
     @property
     def index(self):

--- a/addons/source-python/packages/source-python/players/_base.py
+++ b/addons/source-python/packages/source-python/players/_base.py
@@ -77,11 +77,13 @@ from auth.manager import auth_manager
 class Player(PlayerMixin, Entity):
     """Class used to interact directly with players."""
 
-    def __init__(self, index):
+    def __init__(self, index, caching=True):
         """Initialize the object.
 
         :param int index:
             A valid player index.
+        :param bool caching:
+            Whether to lookup the cache for an existing instance or not.
         :raise ValueError:
             Raised if the index is invalid.
         """

--- a/addons/source-python/packages/source-python/weapons/_base.py
+++ b/addons/source-python/packages/source-python/weapons/_base.py
@@ -27,11 +27,13 @@ __all__ = ('Weapon',
 class Weapon(WeaponMixin, Entity):
     """Allows easy usage of the weapon's attributes."""
 
-    def __init__(self, index):
+    def __init__(self, index, caching=True):
         """Initialize the object.
 
         :param int index:
             A valid weapon index.
+        :param bool caching:
+            Whether to lookup the cache for an existing instance or not.
         :raise ValueError:
             Raised if the index is invalid.
         """


### PR DESCRIPTION
I was curious about the feasibility of the caching @Ayuto suggested into [#284](https://github.com/Source-Python-Dev-Team/Source.Python/pull/284#issuecomment-557653995) so I played a bit with the idea and ended with this implementation. Entity instances are cached by default, unless `caching=False` is passed to the constructor. So, if users want their private instances for whatever reason, they can do so. Ran the following code to time the difference and the results are considerable:

```python
from time import time
from players.entity import Player

class Cached(Player):
    pass

t = time()
for i in range(1000000):
    Cached(1).name
print('Cached:', time() - t)

class NotCached(Player):
    pass

t = time()
for i in range(1000000):
    NotCached(1, caching=False).name
print('NotCached:', time() - t)
```
Results:
```
Cached: 0.9825160503387451
NotCached: 5.010047912597656
```

And here is the code I used to ensure instances were not broken by this implementation:

```python
from entities.entity import Entity
from players.entity import Player
from weapons.entity import Weapon

ent = Entity(0)
assert ent is Entity(0)
ent.index
ent.origin
ent.properties

player = Player(1)
assert player is Player(1)
player.playerinfo
player.name
player.speed

weapon = Weapon._obj(player.give_named_item('weapon_m4a1'))
assert weapon is Weapon(weapon.index)
weapon.clip
weapon.ammo
weapon.index
weapon.next_attack
weapon.remove()

class MyPlayer(Player):
    @property
    def test(self):
        pass

my_player = MyPlayer(player.index)
assert my_player is not player
assert my_player is not MyPlayer(player.index, caching=False)
my_player.name
my_player.test
```