### PR TITLE
Entity.repeat

### DIFF
--- a/addons/source-python/packages/source-python/entities/_base.py
+++ b/addons/source-python/packages/source-python/entities/_base.py
@@ -50,6 +50,8 @@ from filters.weapons import WeaponClassIter
 from listeners import OnEntityDeleted
 from listeners import on_entity_deleted_listener_manager
 from listeners.tick import Delay
+from listeners.tick import Repeat
+from listeners.tick import RepeatStatus
 #   Mathlib
 from mathlib import NULL_VECTOR
 #   Memory
@@ -69,6 +71,9 @@ _projectile_weapons = [weapon.name for weapon in WeaponClassIter('grenade')]
 
 # Get a dictionary to store the delays
 _entity_delays = defaultdict(set)
+
+# Get a dictionary to store the repeats
+_entity_repeats = defaultdict(set)
 
 # Get a set to store the registered entity classes
 _entity_classes = WeakSet()
@@ -817,6 +822,29 @@ class Entity(BaseEntity, metaclass=_EntityCaching):
         # Return the delay instance...
         return delay
 
+    def register_repeat(self, callback, args=(), kwargs=None):
+        """Register a repeat which will be deleted and canceled after removing the entity.
+
+        :param callback:
+            A callable object that should be called at the end of each loop.
+        :param tuple args:
+            Arguments that should be passed to the callback.
+        :param dict kwargs:
+            Keyword arguments that should be passed to the callback.
+        :raise ValueError:
+            Raised if the given callback is not callable.
+        """
+
+        # Get the repeat instance...
+        repeat = Repeat(_callback, args, kwargs)
+
+        # Add the repeat to the dictionary...
+        _entity_repeats[self.index].add(repeat)
+
+        # Return the repeat instance...
+        return repeat
+
+
     def get_input(self, name):
         """Return the input function matching the given name.
 
@@ -1103,19 +1131,30 @@ def _on_entity_deleted(base_entity):
     for cls in _entity_classes:
         cls.cache.pop(index, None)
 
-    # Was no delay registered for this entity?
-    if index not in _entity_delays:
-        return
+    # Was delay registered for this entity?
+    if index in _entity_delays:
+        # Loop through all delays...
+        for delay in _entity_delays[index]:
 
-    # Loop through all delays...
-    for delay in _entity_delays[index]:
+            # Make sure the delay is still running...
+            if not delay.running:
+                continue
 
-        # Make sure the delay is still running...
-        if not delay.running:
-            continue
+            # Cancel the delay...
+            delay.cancel()
 
-        # Cancel the delay...
-        delay.cancel()
+        # Remove the entity from the dictionary...
+        del _entity_delays[index]
 
-    # Remove the entity from the dictionary...
-    del _entity_delays[index]
+    # Was repeat registered for this entity?
+    if index in _entity_repeats:
+        # Loop through all repeats...
+        for repeat in entity_repeats[index]:
+
+            # Stop the repeat if running
+            if repeat.status is RepeatStatus.RUNNING:
+                repeat.stop()
+
+        # Remove the entity from the dictionary...
+        del _entity_repeats[index]
+            

--- a/addons/source-python/packages/source-python/entities/_base.py
+++ b/addons/source-python/packages/source-python/entities/_base.py
@@ -779,7 +779,7 @@ class Entity(BaseEntity, metaclass=_EntityCaching):
     def delay(
             self, delay, callback, args=(), kwargs=None,
             cancel_on_level_end=False):
-        """Execute a callback after the given delay.
+        """Create the delay which will be stopped after removing the entity.
 
         :param float delay:
             The delay in seconds.
@@ -822,8 +822,8 @@ class Entity(BaseEntity, metaclass=_EntityCaching):
         # Return the delay instance...
         return delay
 
-    def repeat(self, callback, args=(), kwargs=None):
-        """Create a repeat which will be stopped after removing the entity.
+    def repeat(self, callback, args=(), kwargs=None, cancel_on_level_end=False):
+        """Create the repeat which will be stopped after removing the entity.
 
         :param callback:
             A callable object that should be called at the end of each loop.
@@ -833,10 +833,12 @@ class Entity(BaseEntity, metaclass=_EntityCaching):
             Keyword arguments that should be passed to the callback.
         :raise ValueError:
             Raised if the given callback is not callable.
+        :param bool cancel_on_level_end:
+            Whether or not to cancel the delay at the end of the map.
         """
 
         # Get the repeat instance...
-        repeat = Repeat(callback, args, kwargs)
+        repeat = Repeat(callback, args, kwargs, cancel_on_level_end)
 
         # Add the repeat to the dictionary...
         _entity_repeats[self.index].add(repeat)

--- a/addons/source-python/packages/source-python/entities/_base.py
+++ b/addons/source-python/packages/source-python/entities/_base.py
@@ -822,8 +822,8 @@ class Entity(BaseEntity, metaclass=_EntityCaching):
         # Return the delay instance...
         return delay
 
-    def register_repeat(self, callback, args=(), kwargs=None):
-        """Register a repeat which will be deleted and canceled after removing the entity.
+    def repeat(self, callback, args=(), kwargs=None):
+        """Create a repeat which will be stopped after removing the entity.
 
         :param callback:
             A callable object that should be called at the end of each loop.
@@ -836,7 +836,7 @@ class Entity(BaseEntity, metaclass=_EntityCaching):
         """
 
         # Get the repeat instance...
-        repeat = Repeat(_callback, args, kwargs)
+        repeat = Repeat(callback, args, kwargs)
 
         # Add the repeat to the dictionary...
         _entity_repeats[self.index].add(repeat)
@@ -1149,7 +1149,7 @@ def _on_entity_deleted(base_entity):
     # Was repeat registered for this entity?
     if index in _entity_repeats:
         # Loop through all repeats...
-        for repeat in entity_repeats[index]:
+        for repeat in _entity_repeats[index]:
 
             # Stop the repeat if running
             if repeat.status is RepeatStatus.RUNNING:

--- a/addons/source-python/packages/source-python/entities/_base.py
+++ b/addons/source-python/packages/source-python/entities/_base.py
@@ -831,10 +831,13 @@ class Entity(BaseEntity, metaclass=_EntityCaching):
             Arguments that should be passed to the callback.
         :param dict kwargs:
             Keyword arguments that should be passed to the callback.
-        :raise ValueError:
-            Raised if the given callback is not callable.
         :param bool cancel_on_level_end:
             Whether or not to cancel the delay at the end of the map.
+        :raise ValueError:
+            Raised if the given callback is not callable.
+        :return:
+            The repeat instance.
+        :rtype: Repeat
         """
 
         # Get the repeat instance...

--- a/addons/source-python/packages/source-python/entities/_base.py
+++ b/addons/source-python/packages/source-python/entities/_base.py
@@ -844,7 +844,6 @@ class Entity(BaseEntity, metaclass=_EntityCaching):
         # Return the repeat instance...
         return repeat
 
-
     def get_input(self, name):
         """Return the input function matching the given name.
 

--- a/addons/source-python/packages/source-python/listeners/tick.py
+++ b/addons/source-python/packages/source-python/listeners/tick.py
@@ -9,7 +9,6 @@
 import bisect
 import math
 import time
-import weakref
 
 from contextlib import suppress
 from enum import IntEnum
@@ -237,9 +236,9 @@ class Repeat(AutoUnload):
             raise ValueError('Given callback is not callable.')
 
         # Store the base attributes
-        self.callback = weakref.ref(callback)
+        self.callback = callback
         self.args = args
-        self.kwargs = WeakValueDictionary(kwargs) if kwargs is not None else dict()
+        self.kwargs = kwargs if kwargs is not None else dict()
         self.cancel_on_level_end = cancel_on_level_end
 
         # Log the __init__ message

--- a/addons/source-python/packages/source-python/listeners/tick.py
+++ b/addons/source-python/packages/source-python/listeners/tick.py
@@ -9,6 +9,7 @@
 import bisect
 import math
 import time
+import weakref
 
 from contextlib import suppress
 from enum import IntEnum
@@ -236,9 +237,9 @@ class Repeat(AutoUnload):
             raise ValueError('Given callback is not callable.')
 
         # Store the base attributes
-        self.callback = callback
+        self.callback = weakref.ref(callback)
         self.args = args
-        self.kwargs = kwargs if kwargs is not None else dict()
+        self.kwargs = WeakValueDictionary(kwargs) if kwargs is not None else dict()
         self.cancel_on_level_end = cancel_on_level_end
 
         # Log the __init__ message


### PR DESCRIPTION
Added analogue for Entity.delay but for Repeat.
```python
from players.entity import Player

def print_alive(player):
    print('Alive')

player = Player(1)

# Will be stopped after removing the entity.
repeat = player.register_repeat(print_alive, (player, ))

# You still can manually stop the repeat.
if player.dead:
    repeat.stop() 
```
Garbage collecting for args of Repeat class.
```python
def __del__(self)
```
never will be called in a Entity subclass if you will pass reference to the instance of Entity object.  
The object remains in the memory forever.

For example:
```python
from random import random

from players.entity import Player
from players.dictionary import PlayerDictionary

class CustomPlayer(Player):
    def __init__(self, index):
        super().__init__(index)
   
        # passed function contains reference to player
        repeat = self.register_repeat(self._print_random_handler)

    # Never will be called.
    def __del__(self):
        print('__del__')

    def _print_random_handler(self):
        print(random())
          
PLAYERS = PlayerDictionary(CustomPlayer)
PLAYERS[1]
```
I barely deal with it using _weakref_ library. But there are still gaps. For example you still can pass the reference like additional argument and again the object never will be deleted. I'm waiting for comments about it.
```python
repeat = self.register_repeat(self._print_random_handler, (self, ))
```