### PR TITLE
Added lazy-loading support to ListenerManager.

### DIFF
--- a/addons/source-python/packages/source-python/__init__.py
+++ b/addons/source-python/packages/source-python/__init__.py
@@ -158,10 +158,10 @@ def setup_data():
         'BaseEntityOutput',
         GameConfigObj(SP_DATA_PATH / 'entity_output' / 'CBaseEntityOutput.ini'))
 
+    from _entities import BaseEntityOutput
     try:
         _fire_output = entities._BaseEntityOutput.fire_output
 
-        from _entities import BaseEntityOutput
         BaseEntityOutput.fire_output = _fire_output
     except ValueError:
         from warnings import warn
@@ -169,15 +169,14 @@ def setup_data():
             'Did not find address for BaseEntityOutput.fire_output. '
             'OnEntityOutput listener will not fire.'
         )
+        BaseEntityOutput.fire_output = NotImplemented
     except AttributeError:
         from warnings import warn
         warn(
             'BaseEntityOutput.fire_output not found. '
             'OnEntityOutput listener will not fire.'
         )
-    else:
-        import listeners
-        _fire_output.add_pre_hook(listeners._pre_fire_output)
+        BaseEntityOutput.fire_output = NotImplemented
 
 
 # =============================================================================

--- a/addons/source-python/packages/source-python/listeners/__init__.py
+++ b/addons/source-python/packages/source-python/listeners/__init__.py
@@ -292,7 +292,7 @@ class OnEntityOutputListenerManager(ListenerManager):
         fire_output = BaseEntityOutput.fire_output
 
         # If the fire_output method is not implemented, exit the call
-        if BaseEntityOutput.fire_output is NotImplemented:
+        if fire_output is NotImplemented:
             return
 
         # Register the hook on fire_output
@@ -304,7 +304,7 @@ class OnEntityOutputListenerManager(ListenerManager):
         fire_output = BaseEntityOutput.fire_output
 
         # If the fire_output method is not implemented, exit the call
-        if BaseEntityOutput.fire_output is NotImplemented:
+        if fire_output is NotImplemented:
             return
 
         # Unregister the hook on fire_output

--- a/addons/source-python/packages/source-python/listeners/__init__.py
+++ b/addons/source-python/packages/source-python/listeners/__init__.py
@@ -24,6 +24,8 @@ from cvars import ConVar
 from cvars import cvar
 #   Engines
 from engines.server import server_game_dll
+#   Entities
+from entities import BaseEntityOutput
 from entities.datamaps import Variant
 from entities.helpers import find_output_name
 #   Memory
@@ -157,7 +159,6 @@ on_plugin_unloaded_manager = ListenerManager()
 on_plugin_loading_manager = ListenerManager()
 on_plugin_unloading_manager = ListenerManager()
 on_level_end_listener_manager = ListenerManager()
-on_entity_output_listener_manager = ListenerManager()
 
 _check_for_update = ConVar(
     'sp_check_for_update',
@@ -279,6 +280,36 @@ class OnClientSettingsChanged(ListenerManagerDecorator):
     """Register/unregister a ClientSettingsChanged listener."""
 
     manager = on_client_settings_changed_listener_manager
+
+
+class OnEntityOutpuListenerManager(ListenerManager):
+    """Register/unregister an EntityOutput listener."""
+
+    def initialize(self):
+        """Called when the first callback is being registered."""
+        # Get the fire_output method
+        fire_output = BaseEntityOutput.fire_output
+
+        # If the fire_output method is not implemented, exit the call
+        if BaseEntityOutput.fire_output is NotImplemented:
+            return
+
+        # Register the hook on fire_output
+        fire_output.add_pre_hook(_pre_fire_output)
+
+    def finalize(self):
+        """Called when the last callback is being unregistered."""
+        # Get the fire_output method
+        fire_output = BaseEntityOutput.fire_output
+
+        # If the fire_output method is not implemented, exit the call
+        if BaseEntityOutput.fire_output is NotImplemented:
+            return
+
+        # Unregister the hook on fire_output
+        fire_output.remove_pre_hook(_pre_fire_output)
+
+on_entity_output_listener_manager = OnEntityOutpuListenerManager()
 
 
 class OnEntityOutput(ListenerManagerDecorator):

--- a/addons/source-python/packages/source-python/listeners/__init__.py
+++ b/addons/source-python/packages/source-python/listeners/__init__.py
@@ -93,6 +93,7 @@ __all__ = ('ButtonStatus',
            'OnEntityCreated',
            'OnEntityDeleted',
            'OnEntityOutput',
+           'OnEntityOutputListenerManager',
            'OnEntityPreSpawned',
            'OnEntitySpawned',
            'OnLevelInit',
@@ -282,7 +283,7 @@ class OnClientSettingsChanged(ListenerManagerDecorator):
     manager = on_client_settings_changed_listener_manager
 
 
-class OnEntityOutpuListenerManager(ListenerManager):
+class OnEntityOutputListenerManager(ListenerManager):
     """Register/unregister an EntityOutput listener."""
 
     def initialize(self):
@@ -309,7 +310,7 @@ class OnEntityOutpuListenerManager(ListenerManager):
         # Unregister the hook on fire_output
         fire_output.remove_pre_hook(_pre_fire_output)
 
-on_entity_output_listener_manager = OnEntityOutpuListenerManager()
+on_entity_output_listener_manager = OnEntityOutputListenerManager()
 
 
 class OnEntityOutput(ListenerManagerDecorator):

--- a/src/core/modules/listeners/listeners_manager.cpp
+++ b/src/core/modules/listeners/listeners_manager.cpp
@@ -48,6 +48,13 @@ void CListenerManager::RegisterListener(PyObject* pCallable)
 	}
 }
 
+void CListenerManager::register_listener(object self, PyObject *pCallable)
+{
+	CListenerManager &pSelf = extract<CListenerManager &>(self);
+	if (!pSelf.GetCount()) self.attr("initialize")();
+	pSelf.RegisterListener(pCallable);
+}
+
 
 //-----------------------------------------------------------------------------
 // Removes all instances of a callable from the CListenerManager vector.
@@ -65,6 +72,13 @@ void CListenerManager::UnregisterListener(PyObject* pCallable)
 	else {
 		m_vecCallables.Remove(index);
 	}
+}
+
+void CListenerManager::unregister_listener(object self, PyObject *pCallable)
+{
+	CListenerManager &pSelf = extract<CListenerManager &>(self);
+	pSelf.UnregisterListener(pCallable);
+	if (!pSelf.GetCount()) self.attr("finalize")();
 }
 
 

--- a/src/core/modules/listeners/listeners_manager.h
+++ b/src/core/modules/listeners/listeners_manager.h
@@ -79,7 +79,7 @@
 //-----------------------------------------------------------------------------
 // CListenerManager class.
 //-----------------------------------------------------------------------------
-class CListenerManager
+class CListenerManager: public wrapper<CListenerManager>
 {
 public:
 	void RegisterListener(PyObject* pCallable);
@@ -90,13 +90,10 @@ public:
 	object __getitem__(unsigned int index);
 	void clear();
 
-	int FindCallback(object oCallback);
+	virtual void Initialize();
+	virtual void Finalize();
 
-	// Lazy-loading support
-	static void register_listener(object self, PyObject *pCallable);
-	static void unregister_listener(object self, PyObject *pCallable);
-	void initialize() {};
-	void finalize() {};
+	int FindCallback(object oCallback);
 
 public:
 	CUtlVector<object> m_vecCallables;

--- a/src/core/modules/listeners/listeners_manager.h
+++ b/src/core/modules/listeners/listeners_manager.h
@@ -92,6 +92,12 @@ public:
 
 	int FindCallback(object oCallback);
 
+	// Lazy-loading support
+	static void register_listener(object self, PyObject *pCallable);
+	static void unregister_listener(object self, PyObject *pCallable);
+	void initialize() {};
+	void finalize() {};
+
 public:
 	CUtlVector<object> m_vecCallables;
 };

--- a/src/core/modules/listeners/listeners_wrap.cpp
+++ b/src/core/modules/listeners/listeners_wrap.cpp
@@ -84,13 +84,13 @@ void export_listener_managers(scope _listeners)
 {
 	class_<CListenerManager, boost::noncopyable>("ListenerManager")
 		.def("register_listener",
-			&CListenerManager::register_listener,
+			&CListenerManager::RegisterListener,
 			"Registers a callable object. If it was already registered it will be ignored.",
 			args("callable")
 		)
 
 		.def("unregister_listener",
-			&CListenerManager::unregister_listener,
+			&CListenerManager::UnregisterListener,
 			"Removes a callable object. If it was not registered nothing will happen.",
 			args("callable")
 		)
@@ -121,12 +121,12 @@ void export_listener_managers(scope _listeners)
 		)
 
 		.def("initialize",
-			&CListenerManager::initialize,
+			&CListenerManager::Initialize,
 			"Called when the first callback is being registered."
 		)
 
 		.def("finalize",
-			&CListenerManager::finalize,
+			&CListenerManager::Finalize,
 			"Called when the last callback is being unregistered."
 		)
 	;

--- a/src/core/modules/listeners/listeners_wrap.cpp
+++ b/src/core/modules/listeners/listeners_wrap.cpp
@@ -84,13 +84,13 @@ void export_listener_managers(scope _listeners)
 {
 	class_<CListenerManager, boost::noncopyable>("ListenerManager")
 		.def("register_listener",
-			&CListenerManager::RegisterListener,
+			&CListenerManager::register_listener,
 			"Registers a callable object. If it was already registered it will be ignored.",
 			args("callable")
 		)
 
 		.def("unregister_listener",
-			&CListenerManager::UnregisterListener,
+			&CListenerManager::unregister_listener,
 			"Removes a callable object. If it was not registered nothing will happen.",
 			args("callable")
 		)
@@ -118,6 +118,16 @@ void export_listener_managers(scope _listeners)
 		.def("clear",
 			&CListenerManager::clear,
 			"Remove all registered callbacks."
+		)
+
+		.def("initialize",
+			&CListenerManager::initialize,
+			"Called when the first callback is being registered."
+		)
+
+		.def("finalize",
+			&CListenerManager::finalize,
+			"Called when the last callback is being unregistered."
 		)
 	;
 


### PR DESCRIPTION
This PR adds lazy-loading support to ListenerManager so that hooks are only registered when a callback is first registered (to fix conflict with SourceMod, see #306).

The implementation is quite simple, when the first callback is registered, `ListenerManager.initialize` is called and `ListenerManager.finalize` is called when the last one is unregistered allowing us to add/remove our hooks only when requested.