### PR TITLE
Add AngleVectors overload to mathlib.

### DIFF
--- a/src/core/modules/mathlib/mathlib_wrap.cpp
+++ b/src/core/modules/mathlib/mathlib_wrap.cpp
@@ -335,9 +335,15 @@ void export_qangle(scope _mathlib)
 		)
 
 		.def("get_angle_vectors",
+			GET_FUNCTION(void, AngleVectors, const QAngle &, Vector *),
+			arg("forward"),
+			"Euler QAngle -> Basis Vectors."
+		)
+
+		.def("get_angle_vectors",
 			GET_FUNCTION(void, AngleVectors, const QAngle &, Vector *, Vector *, Vector *),
-			"Euler QAngle -> Basis Vectors.  Each vector is optional",
-			(arg("forward")=NULL, arg("right")=NULL, arg("up")=NULL)
+			(arg("forward")=NULL, arg("right")=NULL, arg("up")=NULL),
+			"Euler QAngle -> Basis Vectors.  Each vector is optional."
 		)
 
 		.def("__getitem__",


### PR DESCRIPTION
Added new overload.
```python
#   Mathlib
from mathlib import QAngle
from mathlib import Vector

angle = QAngle()
forward = Vector()
angle.get_angle_vectors(forward)
```