### PR TITLE
data: update m4a1_silencer clip and maxammo properties

### DIFF
--- a/addons/source-python/data/source-python/weapons/csgo.ini
+++ b/addons/source-python/data/source-python/weapons/csgo.ini
@@ -118,9 +118,9 @@
 
     [[m4a1_silencer]]
         slot = 0
-        maxammo = 40
+        maxammo = 75
         ammoprop = 4
-        clip = 20
+        clip = 25
         cost = 3100
         item_definition_index = 60
         parent_class = "weapon_m4a1"


### PR DESCRIPTION
Apparently some CS:GO update messed with the clip and maxammo properties again. Verified by buying an M4A1-S and checking the ammo values I got.