### PR TITLE
Added CBaseCombatCharacter::IsInFieldOfView data for CSGO.

### DIFF
--- a/addons/source-python/data/source-python/entities/csgo/CBaseCombatCharacter.ini
+++ b/addons/source-python/data/source-python/entities/csgo/CBaseCombatCharacter.ini
@@ -3,6 +3,13 @@ srv_check = False
 
 [virtual_function]
     
+    # _ZNK20CBaseCombatCharacter15IsInFieldOfViewERK6Vector
+    [[is_in_field_of_view]]
+        offset_linux = 274
+        offset_windows = 273
+        arguments = POINTER
+        return_type = BOOL
+
     # _ZN20CBaseCombatCharacter18OnTakeDamage_AliveERK15CTakeDamageInfo
     [[on_take_damage_alive]]
         offset_linux = 299

--- a/addons/source-python/packages/source-python/players/engines/csgo/__init__.py
+++ b/addons/source-python/packages/source-python/players/engines/csgo/__init__.py
@@ -166,21 +166,6 @@ class Player(_Player):
         # unk2 is a Vector (position)? Should do some tests...
         return [item, sub_type, econ_item_view, unk, unk2]
 
-    @wrap_entity_mem_func
-    def is_in_field_of_view(self, target):
-        """Checks if the given position is within the player's field of view.
-        
-        .. note::
-            This function does not check if the player's view of the given 
-            position is blocked by something (brush, prop, another entity).
-
-        :param Vector target:
-            A valid point (x, y, z) within the game world.
-
-        :rtype: bool
-        """
-        return [target]
-
 
 # =============================================================================
 # >> CALLBACKS

--- a/addons/source-python/packages/source-python/players/engines/csgo/__init__.py
+++ b/addons/source-python/packages/source-python/players/engines/csgo/__init__.py
@@ -159,11 +159,27 @@ class Player(_Player):
         self._spawn()
 
     @wrap_entity_mem_func
-    def give_named_item(self, item, sub_type=0, econ_item_view=None, unk=False, unk2=NULL):
+    def give_named_item(
+            self, item, sub_type=0, econ_item_view=None, unk=False, unk2=NULL):
         """Give the player a named item."""
         # TODO: What's the unk argument for?
         # unk2 is a Vector (position)? Should do some tests...
         return [item, sub_type, econ_item_view, unk, unk2]
+
+    @wrap_entity_mem_func
+    def is_in_field_of_view(self, target):
+        """Checks if the given position is within the player's field of view.
+        
+        .. note::
+            This function does not check if the player's view of the given 
+            position is blocked by something (brush, prop, another entity).
+
+        :param Vector target:
+            A valid point (x, y, z) within the game world.
+
+        :rtype: bool
+        """
+        return [target]
 
 
 # =============================================================================


### PR DESCRIPTION
###### As promised: https://forums.sourcepython.com/viewtopic.php?f=7&t=1866#p13834
I wanted to add the data for other games as well, but after testing the virtual function in HL2DM and CSS, I gave up. The function always returns True, even when it shouldn't. 

I'll see if the other [CBaseCombatCharacter::IsInFieldOfView()](https://github.com/alliedmodders/hl2sdk/blob/0ef5d3d482157bc0bb3aafd37c08961373f87bfd/game/shared/basecombatcharacter_shared.cpp#L615) function that takes an entity as an argument instead of a vector works in those games. 

If it does work, how should I handle different virtual functions that have the same name? Do I just change the name of the function in the data file? (**is_in_field_of_view** and **is_in_field_of_view_vec**)
Or is there some form of overloading we can do?