### PR TITLE
Added CItem::Materialize and CBaseCombatWeapon::Materialize data for HL2DM.

### DIFF
--- a/addons/source-python/data/source-python/entities/orangebox/hl2mp/CBaseCombatWeapon.ini
+++ b/addons/source-python/data/source-python/entities/orangebox/hl2mp/CBaseCombatWeapon.ini
@@ -9,3 +9,8 @@
     [[secondary_attack]]
         offset_linux = 275
         offset_windows = 274
+
+    # _ZN17CBaseCombatWeapon11MaterializeEv
+    [[materialize]]
+        offset_linux = 349
+        offset_windows = 348

--- a/addons/source-python/data/source-python/entities/orangebox/hl2mp/CItem.ini
+++ b/addons/source-python/data/source-python/entities/orangebox/hl2mp/CItem.ini
@@ -1,0 +1,6 @@
+[virtual_function]
+    
+    # _ZN5CItem11MaterializeEv
+    [[materialize]]
+        offset_linux = 218
+        offset_windows = 217


### PR DESCRIPTION
Weapons and items in HL2DM are only spawned once. They get disabled when picked up by a player, and after a while (`sv_hl2mp_weapon_respawn_time`, `sv_hl2mp_item_respawn_time`) they are re-enabled.

As such, using an OnEntitySpawned/Created listener for these entities is pretty much pointless.
With [CItem::Materialize()](https://github.com/alliedmodders/hl2sdk/blob/0ef5d3d482157bc0bb3aafd37c08961373f87bfd/game/server/item_world.cpp#L486) and [CBaseCombatWeapon::Materialize()](https://github.com/alliedmodders/hl2sdk/blob/0ef5d3d482157bc0bb3aafd37c08961373f87bfd/game/server/basecombatweapon.cpp#L565), we can get access to these entities when they are re-enabled.
