### PR TITLE
Added the ability to disable hooks

### DIFF
--- a/addons/source-python/packages/source-python/memory/hooks.py
+++ b/addons/source-python/packages/source-python/memory/hooks.py
@@ -5,11 +5,16 @@
 # =============================================================================
 # >> IMPORTS
 # =============================================================================
+# Python
+from contextlib import contextmanager
+
 # Source.Python Imports
 #   Core
 from core import AutoUnload
 #   Memory
 from _memory import HookType
+from _memory import set_hooks_disabled
+from _memory import get_hooks_disabled
 from memory import Function
 
 
@@ -19,6 +24,9 @@ from memory import Function
 __all__ = ('HookType',
            'PostHook',
            'PreHook',
+           'set_hooks_disabled',
+           'get_hooks_disabled',
+           'hooks_disabled'
            )
 
 
@@ -73,3 +81,18 @@ class PostHook(_Hook):
     """Decorator class used to create post hooks that auto unload."""
 
     hook_type = HookType.POST
+
+
+# =============================================================================
+# >> FUNCTIONS
+# =============================================================================
+@contextmanager
+def hooks_disabled(disabled=True):
+    """Temporarily disable or enable all hook callbacks. If the context ends,
+    the original value is restored."""
+    old = get_hooks_disabled()
+    set_hooks_disabled(disabled)
+    try:
+        yield
+    finally:
+        set_hooks_disabled(old)

--- a/addons/source-python/packages/source-python/memory/hooks.py
+++ b/addons/source-python/packages/source-python/memory/hooks.py
@@ -88,8 +88,34 @@ class PostHook(_Hook):
 # =============================================================================
 @contextmanager
 def hooks_disabled(disabled=True):
-    """Temporarily disable or enable all hook callbacks. If the context ends,
-    the original value is restored."""
+    """Temporarily disable or enable all hook callbacks. By default hooks are
+    enabled. Thus, this context manager is mainly used to temporarily disable
+    hook callbacks. If the context ends, the original value is restored. This
+    can be used e. g. to avoid recursive calls when damaging a player in a
+    ``on_take_damage`` hook or ``player_hurt`` event.
+
+    .. note::
+
+        This would only disable hooks created with Source.Python. Hooks that
+        have been created by other server plugins will still be called.
+
+    Example:
+
+    .. code:: python
+
+        from players.entity import Player
+        from memory.hooks import hooks_disabled
+
+        # Get a Player instance of the player with index 1
+        player = Player(1)
+
+        # Damage the player. This would call e. g. on_take_damage hooks
+        player.take_damage(5)
+
+        # To avoid calling the on_take_damage hooks, use the following:
+        with hooks_disabled()
+            player.take_damage(5)
+    """
     old = get_hooks_disabled()
     set_hooks_disabled(disabled)
     try:

--- a/src/core/modules/memory/memory_hooks.cpp
+++ b/src/core/modules/memory/memory_hooks.cpp
@@ -44,6 +44,8 @@ using namespace boost::python;
 // g_mapCallbacks[<CHook *>][<HookType_t>] -> [<object>, <object>, ...]
 std::map<CHook *, std::map<HookType_t, std::list<object> > > g_mapCallbacks;
 
+bool g_HooksDisabled;
+
 
 // ============================================================================
 // >> HELPER FUNCTIONS
@@ -83,7 +85,7 @@ bool SP_HookHandler(HookType_t eHookType, CHook* pHook)
 	std::list<object> callbacks = g_mapCallbacks[pHook][eHookType];
 
 	// No need to do all this stuff, if there is no callback registered
-	if (callbacks.empty())
+	if (g_HooksDisabled || callbacks.empty())
 		return false;
 
 	object retval;

--- a/src/core/modules/memory/memory_hooks.cpp
+++ b/src/core/modules/memory/memory_hooks.cpp
@@ -82,10 +82,13 @@ object GetArgument(CHook* pHook, int iIndex)
 // ============================================================================
 bool SP_HookHandler(HookType_t eHookType, CHook* pHook)
 {
+	if (g_HooksDisabled)
+		return false;
+
 	std::list<object> callbacks = g_mapCallbacks[pHook][eHookType];
 
 	// No need to do all this stuff, if there is no callback registered
-	if (g_HooksDisabled || callbacks.empty())
+	if (callbacks.empty())
 		return false;
 
 	object retval;

--- a/src/core/modules/memory/memory_hooks.h
+++ b/src/core/modules/memory/memory_hooks.h
@@ -76,4 +76,16 @@ protected:
 //---------------------------------------------------------------------------------
 bool SP_HookHandler(HookType_t eHookType, CHook* pHook);
 
+extern bool g_HooksDisabled;
+
+inline void SetHooksDisabled(bool value)
+{
+	g_HooksDisabled = value;
+}
+
+inline bool GetHooksDisabled()
+{
+	return g_HooksDisabled;
+}
+
 #endif // MEMORY_HOOKS_H

--- a/src/core/modules/memory/memory_wrap.cpp
+++ b/src/core/modules/memory/memory_wrap.cpp
@@ -68,6 +68,8 @@ void export_protection(scope);
 // ============================================================================
 DECLARE_SP_MODULE(_memory)
 {
+	SetHooksDisabled(false);
+
 	export_function_info(_memory);
 	export_binary_file(_memory);
 	export_pointer(_memory);
@@ -956,6 +958,18 @@ void export_functions(scope _memory)
 		":param DataType data_type: The data type you would like to get the size of.\n"
 		":param int alignment: The alignment that should be used."
 	);
+
+	def("get_hooks_disabled",
+		&GetHooksDisabled,
+		"Return whether or not hook callbacks are disabled.\n"
+		"\n"
+		":rtype: bool");
+
+	def("set_hooks_disabled",
+		&SetHooksDisabled,
+		"Set whether or not hook callbacks are disabled.\n"
+		"\n"
+		":param bool disabled: If ``True``, hook callbacks are disabled.");
 }
 
 


### PR DESCRIPTION
Generic fix for issue #236

Test code:
```python
from memory.hooks import hooks_disabled
from entities.hooks import EntityPreHook, EntityCondition
from events import Event
from players.entity import Player

@EntityPreHook(EntityCondition.is_human_player, 'on_take_damage')
def pre_take_damage(args):
    print('take damage', args)

@Event('player_say')
def on_player_say(event):
    player = Player.from_userid(event['userid'])
    target = player.view_player
    if target is None:
        print('not a player or no target')
        return

    with hooks_disabled(event['text'] == 'yes'):
        target.take_damage(5)
```
When looking at a player and typing ``yes``, the hook shouldn't get called. In all other cases the hook gets called.