### PR TITLE
data: Add weapon MP5-SD for CS:GO

### DIFF
--- a/addons/source-python/data/source-python/weapons/csgo.ini
+++ b/addons/source-python/data/source-python/weapons/csgo.ini
@@ -163,6 +163,15 @@
         item_definition_index = 33
         tags = "all,primary,smg"
 
+    [[mp5sd]]
+        slot = 0
+        maxammo = 120
+        ammoprop = 7
+        clip = 30
+        cost = 1500
+        item_definition_index = 23
+        tags = "all,primary,smg"
+
     [[mp9]]
         slot = 0
         maxammo = 120


### PR DESCRIPTION
I just saw that the [MP5-SD](https://developer.valvesoftware.com/wiki/Weapon_mp5sd) was missing from CS:GO.

The values I **know**:
- slot
- maxammo
- clip
- cost
- tags
- item_definition_index

The values I **don't know** and should be reviewed:
- ammoprop

Please tell me if they need to be corrected!