### PR TITLE
Modified player.get_godmode() for CSGO.

### DIFF
--- a/addons/source-python/data/source-python/entities/csgo/CCSPlayer.ini
+++ b/addons/source-python/data/source-python/entities/csgo/CCSPlayer.ini
@@ -94,6 +94,7 @@ srv_check = False
     player_class = m_iClass
     player_state = m_iPlayerState
     ragdoll = m_hRagdoll
+    gungame_immunity = m_bGunGameImmunity
 
     [[eye_angle]]
         name = m_angEyeAngles[0]

--- a/addons/source-python/packages/source-python/players/engines/csgo/__init__.py
+++ b/addons/source-python/packages/source-python/players/engines/csgo/__init__.py
@@ -78,6 +78,13 @@ class Player(_Player):
         _get_assists, _set_assists,
         doc="""The number of assists a player has.""")
 
+    @_Player.godmode.getter
+    def godmode(self):
+        """Return whether god mode is enabled.
+        :rtype: bool
+        """
+        return super().get_godmode() or self.gungame_immunity
+
     def send_convar_value(self, cvar_name, value):
         """Send a convar value.
 


### PR DESCRIPTION
Godmode granted through spawn protection or other sources within official gamemodes (deathmatch, arms race) isn't covered by the **m_takedamage** property. With this change, checking if a player has godmode in CSGO should always work.