### PR TITLE
Fixed an issue where Non-networked entities could not be created.

### DIFF
--- a/src/core/modules/entities/entities_entity.cpp
+++ b/src/core/modules/entities/entities_entity.cpp
@@ -83,6 +83,7 @@ object CBaseEntityWrapper::create(object cls, const char *name)
 	}
 	catch (...)
 	{
+		PyErr_Clear();
 		try
 		{
 			CPointer tmp = pEntity->GetPointer();
@@ -127,6 +128,7 @@ object CBaseEntityWrapper::find(object cls, const char *name)
 		}
 		catch (...)
 		{
+			PyErr_Clear();
 			try
 			{
 				CPointer tmp = pEntity->GetPointer();


### PR DESCRIPTION
This solves the problem of creating Non-networked entities.

This issue was discovered by @progre.

Code:
```python
# Source.Python Imports
#   Entities
from entities.entity import BaseEntity
BaseEntity.create("info_player_terrorist")
```

Output:
```
[SP] Caught an Exception:
ValueError: Conversion from "BaseEntity" (<_entities._entity.BaseEntity object at 0xed1eb980>) to "Index" failed.

The above exception was the direct cause of the following exception:
SystemError: <Boost.Python.function object at 0x9be5020> returned a result with an error set

The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "../addons/source-python/packages/source-python/plugins/command.py", line 164, in load_plugin
    plugin = self.manager.load(plugin_name)
  File "../addons/source-python/packages/source-python/plugins/manager.py", line 194, in load
    plugin._load()
  File "../addons/source-python/packages/source-python/plugins/instance.py", line 74, in _load
    self.module = import_module(self.import_name)
  File "../addons/source-python/plugins/test/test.py", line 10, in <module>
    BaseEntity.create("info_player_terrorist")
```
or

Output:
```
SystemError: <built-in function __import__> returned a result with an error set

[SP] Caught an Exception:
Traceback (most recent call last):
  File "../addons/source-python/packages/source-python/plugins/command.py", line 164, in load_plugin
    plugin = self.manager.load(plugin_name)
  File "../addons/source-python/packages/source-python/plugins/manager.py", line 194, in load
    plugin._load()
  File "../addons/source-python/packages/source-python/plugins/instance.py", line 74, in _load
    self.module = import_module(self.import_name)
  File "../addons/source-python/plugins/test/test.py", line 10, in <module>
    BaseEntity.create("info_player_terrorist")

ValueError: Unable to make a 'BaseEntity' instance out of this 'info_player_terrorist' entity.
```

When getting the Index of a Non-networked entity, an exception will be raised, so we need to clear the error indicator.
https://github.com/Source-Python-Dev-Team/Source.Python/blob/d65dc58d5e4b89293973c61a2a06bdae91592ee1/src/core/utilities/conversions.h#L81-L93