### PR TITLE
Fixed a typo in one of the CFogController inputs.

### DIFF
--- a/addons/source-python/data/source-python/entities/CFogController.ini
+++ b/addons/source-python/data/source-python/entities/CFogController.ini
@@ -2,7 +2,7 @@
 
     set_angles = SetAngles
     set_color = SetColor
-    set_color_lerp_to = SetColorLerpTO
+    set_color_lerp_to = SetColorLerpTo
     set_color_secondary = SetColorSecondary
     set_color_secondary_lerp_to = SetColorSecondaryLerpTo
     set_end_dist = SetEndDist


### PR DESCRIPTION
Took me a while to realize why `AttributeError: Attribute "set_color_lerp_to" not found` kept popping up. 