### PR TITLE
Add trampoline property to CFunction.

### DIFF
--- a/src/core/modules/memory/memory_function.cpp
+++ b/src/core/modules/memory/memory_function.cpp
@@ -321,6 +321,16 @@ object CFunction::Call(tuple args, dict kw)
 	return object();
 }
 
+object CFunction::CallTrampoline(tuple args, dict kw)
+{
+	CHook* pHook = GetHookManager()->FindHook((void *) m_ulAddr);
+	if (!pHook)
+		BOOST_RAISE_EXCEPTION(PyExc_ValueError, "Function was not hooked.")
+
+	return CFunction((unsigned long) pHook->m_pTrampoline, m_eCallingConvention,
+		m_iCallingConvention, m_tArgs, m_eReturnType, m_oConverter).Call(args, kw);
+}
+
 object CFunction::SkipHooks(tuple args, dict kw)
 {
 	CHook* pHook = GetHookManager()->FindHook((void *) m_ulAddr);

--- a/src/core/modules/memory/memory_function.cpp
+++ b/src/core/modules/memory/memory_function.cpp
@@ -337,10 +337,10 @@ object CFunction::SkipHooks(tuple args, dict kw)
 unsigned long CFunction::GetTrampolineAddress()
 {
 	CHook* pHook = GetHookManager()->FindHook((void *) m_ulAddr);
-	if (pHook)
-		return (unsigned long) pHook->m_pTrampoline;
+	if (!pHook)
+		BOOST_RAISE_EXCEPTION(PyExc_ValueError, "Function was not hooked.")
 
-	return m_ulAddr;
+	return (unsigned long) pHook->m_pTrampoline;
 }
 
 CHook* HookFunctionHelper(void* addr, ICallingConvention* pConv)

--- a/src/core/modules/memory/memory_function.cpp
+++ b/src/core/modules/memory/memory_function.cpp
@@ -176,7 +176,6 @@ CFunction::CFunction(unsigned long ulAddr, Convention_t eCallingConvention,
 	m_eCallingConvention = eCallingConvention;
 	m_iCallingConvention = iCallingConvention;
 	m_pCallingConvention = NULL;
-	m_oCallingConvention = object();
 
 	// We didn't allocate the calling convention, someone else is responsible for it.
 	m_bAllocatedCallingConvention = false;

--- a/src/core/modules/memory/memory_function.cpp
+++ b/src/core/modules/memory/memory_function.cpp
@@ -334,6 +334,15 @@ object CFunction::SkipHooks(tuple args, dict kw)
 	return Call(args, kw);
 }
 
+unsigned long CFunction::GetTrampolineAddress()
+{
+	CHook* pHook = GetHookManager()->FindHook((void *) m_ulAddr);
+	if (pHook)
+		return (unsigned long) pHook->m_pTrampoline;
+
+	return m_ulAddr;
+}
+
 CHook* HookFunctionHelper(void* addr, ICallingConvention* pConv)
 {
 	CHook* result;

--- a/src/core/modules/memory/memory_function.h
+++ b/src/core/modules/memory/memory_function.h
@@ -66,20 +66,22 @@ public:
 	bool IsHookable();
 
 	bool IsHooked();
-    
+
 	object Call(boost::python::tuple args, dict kw);
 	object CallTrampoline(boost::python::tuple args, dict kw);
 	object SkipHooks(boost::python::tuple args, dict kw);
-	
+
+	unsigned long GetTrampolineAddress();
+
 	void AddHook(HookType_t eType, PyObject* pCallable);
 	void RemoveHook(HookType_t eType, PyObject* pCallable);
-    
+
 	void AddPreHook(PyObject* pCallable)
 	{ return AddHook(HOOKTYPE_PRE, pCallable); }
 
 	void AddPostHook(PyObject* pCallable)
 	{ return AddHook(HOOKTYPE_POST, pCallable); }
-    
+
 	void RemovePreHook(PyObject* pCallable)
 	{ RemoveHook(HOOKTYPE_PRE, pCallable); }
 
@@ -87,7 +89,7 @@ public:
 	{ RemoveHook(HOOKTYPE_POST, pCallable);	}
 
 	void DeleteHook();
-    
+
 public:
 	boost::python::tuple	m_tArgs;
 	object					m_oConverter;

--- a/src/core/modules/memory/memory_function.h
+++ b/src/core/modules/memory/memory_function.h
@@ -69,6 +69,7 @@ public:
 	CFunction* GetTrampoline();
 
 	object Call(boost::python::tuple args, dict kw);
+	object CallTrampoline(boost::python::tuple args, dict kw);
 	object SkipHooks(boost::python::tuple args, dict kw);
 
 	void AddHook(HookType_t eType, PyObject* pCallable);

--- a/src/core/modules/memory/memory_function.h
+++ b/src/core/modules/memory/memory_function.h
@@ -57,8 +57,7 @@ class CFunction: public CPointer, private boost::noncopyable
 public:
 	CFunction(unsigned long ulAddr, object oCallingConvention, object oArgs, object oReturnType);
 	CFunction(unsigned long ulAddr, Convention_t eCallingConvention, int iCallingConvention,
-		ICallingConvention* pCallingConvention, boost::python::tuple tArgs,
-		DataType_t eReturnType, object oConverter);
+		boost::python::tuple tArgs, DataType_t eReturnType, object oConverter);
 
 	~CFunction();
 
@@ -67,11 +66,10 @@ public:
 
 	bool IsHooked();
 
-	object Call(boost::python::tuple args, dict kw);
-	object CallTrampoline(boost::python::tuple args, dict kw);
-	object SkipHooks(boost::python::tuple args, dict kw);
+	CFunction* GetTrampoline();
 
-	unsigned long GetTrampolineAddress();
+	object Call(boost::python::tuple args, dict kw);
+	object SkipHooks(boost::python::tuple args, dict kw);
 
 	void AddHook(HookType_t eType, PyObject* pCallable);
 	void RemoveHook(HookType_t eType, PyObject* pCallable);

--- a/src/core/modules/memory/memory_wrap.cpp
+++ b/src/core/modules/memory/memory_wrap.cpp
@@ -476,6 +476,11 @@ void export_function(scope _memory)
 			"Return True if the function is hooked."
 		)
 
+		.def("call_trampoline",
+			raw_method(&CFunction::CallTrampoline),
+			"Calls the trampoline function dynamically."
+		)
+
 		.def("skip_hooks",
 			raw_method(&CFunction::SkipHooks),
 			"Call the function, but skip hooks if there are any."

--- a/src/core/modules/memory/memory_wrap.cpp
+++ b/src/core/modules/memory/memory_wrap.cpp
@@ -476,11 +476,6 @@ void export_function(scope _memory)
 			"Return True if the function is hooked."
 		)
 
-		.def("call_trampoline",
-			raw_method(&CFunction::CallTrampoline),
-			"Calls the trampoline function dynamically."
-		)
-
 		.def("skip_hooks",
 			raw_method(&CFunction::SkipHooks),
 			"Call the function, but skip hooks if there are any."
@@ -541,9 +536,9 @@ void export_function(scope _memory)
 		)
 
 		// Properties
-		.add_property("trampoline_address",
-			&CFunction::GetTrampolineAddress,
-			"Return the trampoline address if the function is hooked, otherwise return the function address."
+		.add_property("trampoline",
+			make_function(&CFunction::GetTrampoline, manage_new_object_policy()),
+			"Return the trampoline function if the function is hooked."
 		)
 	;
 }

--- a/src/core/modules/memory/memory_wrap.cpp
+++ b/src/core/modules/memory/memory_wrap.cpp
@@ -539,6 +539,12 @@ void export_function(scope _memory)
 		.def_readonly("convention",
 			&CFunction::m_eCallingConvention
 		)
+
+		// Properties
+		.add_property("trampoline_address",
+			&CFunction::GetTrampolineAddress,
+			"Return the trampoline address if the function is hooked, otherwise return the function address."
+		)
 	;
 }
 


### PR DESCRIPTION
This change allows hooked function to be called dynamically from other function libraries.