### PR TITLE
Update CS:GO assists offset for Windows/Linux

### DIFF
--- a/addons/source-python/data/source-python/entities/csgo/CBasePlayer.ini
+++ b/addons/source-python/data/source-python/entities/csgo/CBasePlayer.ini
@@ -74,8 +74,8 @@ srv_check = False
             # break
     # print('Offset of Player.assists is:', offset)
     [[assists]]
-        offset_windows = 3172
-        offset_linux = 3196
+        offset_windows = 3204
+        offset_linux = 3228
         type = INT
 
 


### PR DESCRIPTION
Hello, thanks for an amazing project.

After seeing some weirdness with getting/setting player assist values in CS:GO, I did some investigation and it appears that the offset for assists has changed. I obtained these from running the snippet of commented code above the assists offset data on a CS:GO server on Windows and Linux:

Windows: `Offset of Player.assists is: 3204`
Linux: `Offset of Player.assists is: 3228`

This PR sets those values. Apologies if I missed something or have made a mistake. Thanks again!