### PR TITLE
Removed caching of the physics_object property.

### DIFF
--- a/src/core/modules/entities/entities_entity_wrap.cpp
+++ b/src/core/modules/entities/entities_entity_wrap.cpp
@@ -534,7 +534,6 @@ void export_base_entity(scope _entity)
 		make_function(&CBaseEntityWrapper::GetPhysicsObject, manage_new_object_policy()),
 		"Return the physics object of the entity.\n\n"
 		":rtype: PhysicsObject");
-	cached_property(BaseEntity, "physics_object");
 
 	// KeyValue getter methods
 	BaseEntity.def("get_key_value_string",


### PR DESCRIPTION
Previous discussion: https://github.com/Source-Python-Dev-Team/Source.Python/issues/357