### PR TITLE
Fix remove entity listener

### DIFF
--- a/src/core/modules/entities/entities_wrap.cpp
+++ b/src/core/modules/entities/entities_wrap.cpp
@@ -531,7 +531,7 @@ void export_global_entity_list(scope _entities)
 		)
 
 		.def("remove_entity_listener",
-			&CGlobalEntityList::AddListenerEntity
+			&CGlobalEntityList::RemoveListenerEntity
 		)
 
 		ADD_MEM_TOOLS(CGlobalEntityList);


### PR DESCRIPTION
When browsing the source code I noticed this typo which was binding "AddListenerEntity" to both add and remove entity listener on the python side.

This only gets called on SP unload so changing this probably doesn't actually do much in the end.