### PR TITLE
Added default argument to Send/Deny/RequestFile functions.

### DIFF
--- a/src/core/modules/net_channel/net_channel_wrap.cpp
+++ b/src/core/modules/net_channel/net_channel_wrap.cpp
@@ -91,17 +91,47 @@ void export_net_channel(scope _net_channel)
 	);
 
 	NetChannel.def(
+		"set_data_rate",
+		&INetChannel::SetDataRate
+	);
+
+#if defined(ENGINE_BLADE) || defined(ENGINE_CSGO) || defined(ENGINE_LEFT4DEAD2)
+	NetChannel.def(
 		"send_file",
-		&INetChannel::SendFile
+		&INetChannel::SendFile,
+		(arg("file_name"), arg("transfer_id"), arg("is_replay_demo")=false)
+	);
+
+	NetChannel.def(
+		"deny_file",
+		&INetChannel::DenyFile,
+		(arg("file_name"), arg("transfer_id"), arg("is_replay_demo")=false)
 	);
 
 	NetChannel.def(
 		"request_file",
-		&INetChannel::RequestFile);
+		&INetChannel::RequestFile,
+		(arg("file_name"), arg("is_replay_demo")=false)
+	);
+#else
+	NetChannel.def(
+		"send_file",
+		&INetChannel::SendFile,
+		(arg("file_name"), arg("transfer_id"))
+	);
 
 	NetChannel.def(
 		"deny_file",
-		&INetChannel::DenyFile);
+		&INetChannel::DenyFile,
+		(arg("file_name"), arg("transfer_id"))
+	);
+
+	NetChannel.def(
+		"request_file",
+		&INetChannel::RequestFile,
+		(arg("file_name"))
+	);
+#endif
 
 	NetChannel.def(
 		"send_data",


### PR DESCRIPTION
This eliminates unnecessary condition checks.

Before:
```python
# Source.Python Imports
#   Core
from core import SOURCE_ENGINE
#   Players
from players.entity import Player

player = Player(1)
if SOURCE_ENGINE in ("blade", "csgo", "l4d2"):
    player.client.net_channel.send_file(file_name, transfer_id, False)
else:
    player.client.net_channel.send_file(file_name, transfer_id)
```
After:
```python
# Source.Python Imports
#   Players
from players.entity import Player

player = Player(1)
player.client.net_channel.send_file(file_name, transfer_id)
```