### PR TITLE
Changed AutoUnload to be able to manage objects generated from custom packages.

### DIFF
--- a/addons/source-python/packages/source-python/core/__init__.py
+++ b/addons/source-python/packages/source-python/core/__init__.py
@@ -114,8 +114,13 @@ class AutoUnload(object):
         path = frame.f_code.co_filename
 
         # Don't keep hostage instances that will never be unloaded
-        if not path.startswith(PLUGIN_PATH):
-            return self
+        while not path.startswith(PLUGIN_PATH):
+            frame = frame.f_back
+            if frame is None:
+                return self
+            path = frame.f_code.co_filename
+            if path.startswith('<frozen'):
+                return self
 
         # Resolve the calling module name
         try:


### PR DESCRIPTION
This ensures the code that generates objects that expect `unload` in the custom packages works correctly.
```python
# addons/source-python/packages/custom/test/__init__.py

# Source.Python Imports
#   Core
from core import AutoUnload

class Test(AutoUnload):
    def __init__(self):
        print("init Test")
    def _unload_instance(self):
        print("unloaded Test")

def test():
    return Test()
```
```python
# addons/source-python/plugins/test_plugin/test_plugin.py

from test import Test
from test import test

Test()
test()
```
Output:
```
sp plugin load test_plugin
[SP] Loading plugin 'test_plugin'...
init Test
init Test
[SP] Successfully loaded plugin 'test_plugin'.
sp plugin unload test_plugin
[SP] Unloading plugin 'test_plugin'...
unloaded Test
unloaded Test
[SP] Successfully unloaded plugin 'test_plugin'.
```