### PR TITLE
Added a set_attacker function to CBaseCSGrenadeProjectile for CS:GO.

### DIFF
--- a/addons/source-python/data/source-python/entities/csgo/CBaseCSGrenadeProjectile.ini
+++ b/addons/source-python/data/source-python/entities/csgo/CBaseCSGrenadeProjectile.ini
@@ -1,3 +1,14 @@
+srv_check = False
+
+
+[function]
+
+    [[set_attacker]]
+        identifier_windows = 55 8B EC 53 8B 5D 08 56 57 8B F9 53
+        identifier_linux = 55 89 E5 57 56 53 83 EC 2C C7 45 DC 00 00 00 00 8B 5D 08
+        arguments = POINTER
+
+
 [property]
 
     bounces = m_nBounces

--- a/addons/source-python/packages/source-python/entities/engines/csgo/csgo.py
+++ b/addons/source-python/packages/source-python/entities/engines/csgo/csgo.py
@@ -74,5 +74,5 @@ class Entity(_Entity):
 
     thrower = property(
         lambda self: self.__getattr__('thrower'),
-        lambda self, value: self.set_attacker(pointer_from_inthandle(value))
+        lambda self, inthandle: self.set_attacker(pointer_from_inthandle(inthandle))
     )

--- a/addons/source-python/packages/source-python/entities/engines/csgo/csgo.py
+++ b/addons/source-python/packages/source-python/entities/engines/csgo/csgo.py
@@ -6,8 +6,11 @@
 # >> IMPORTS
 # =============================================================================
 # Source.Python
-from entities import BaseEntityGenerator
+#   Entities
 from . import Entity as _Entity
+from entities import BaseEntityGenerator
+from entities.helpers import pointer_from_inthandle
+#   Weapons
 from weapons.manager import weapon_manager
 
 
@@ -68,3 +71,8 @@ class Entity(_Entity):
                 ) in (index, 0):
                     return cls(entity.index)
         return super().find(classname)
+
+    thrower = property(
+        lambda self: self.__getattr__('thrower'),
+        lambda self, value: self.set_attacker(pointer_from_inthandle(value))
+    )


### PR DESCRIPTION
This function allows you to properly set the attacker on the Projectile.

If you think there is a problem with the name, please suggest a new name.