### PR TITLE
Fixed a problem with dangling references around ExtractPointer. (#334, #372, #373)

### DIFF
--- a/src/core/modules/memory/memory_function.cpp
+++ b/src/core/modules/memory/memory_function.cpp
@@ -280,7 +280,7 @@ object CFunction::Call(tuple args, dict kw)
 			{
 				unsigned long ulAddr = 0;
 				if (arg.ptr() != Py_None)
-					ulAddr = ExtractPointer(arg)->m_ulAddr;
+					ulAddr = ExtractAddress(arg);
 
 				dcArgPointer(g_pCallVM, ulAddr);
 				break;

--- a/src/core/modules/memory/memory_hooks.cpp
+++ b/src/core/modules/memory/memory_hooks.cpp
@@ -147,7 +147,7 @@ bool SP_HookHandler(HookType_t eHookType, CHook* pHook)
 					case DATA_TYPE_DOUBLE:		SetReturnValue<double>(pHook, pyretval); break;
 					case DATA_TYPE_POINTER:
 					{
-						pHook->SetReturnValue<unsigned long>(ExtractPointer(pyretval)->m_ulAddr);
+						pHook->SetReturnValue<unsigned long>(ExtractAddress(pyretval));
 					} break;
 					case DATA_TYPE_STRING:		SetReturnValue<const char*>(pHook, pyretval); break;
 					default: BOOST_RAISE_EXCEPTION(PyExc_TypeError, "Unknown type.")
@@ -224,7 +224,7 @@ void CStackData::SetItem(unsigned int iIndex, object value)
 		case DATA_TYPE_DOUBLE:		SetArgument<double>(m_pHook, iIndex, value); break;
 		case DATA_TYPE_POINTER:
 		{
-			SetArgument<unsigned long>(m_pHook, iIndex, object(ExtractPointer(value)->m_ulAddr));
+			SetArgument<unsigned long>(m_pHook, iIndex, object(ExtractAddress(value)));
 		} break;
 		case DATA_TYPE_STRING:		SetArgument<const char *>(m_pHook, iIndex, value); break;
 		default: BOOST_RAISE_EXCEPTION(PyExc_TypeError, "Unknown type.")

--- a/src/core/modules/memory/memory_hooks.cpp
+++ b/src/core/modules/memory/memory_hooks.cpp
@@ -147,8 +147,7 @@ bool SP_HookHandler(HookType_t eHookType, CHook* pHook)
 					case DATA_TYPE_DOUBLE:		SetReturnValue<double>(pHook, pyretval); break;
 					case DATA_TYPE_POINTER:
 					{
-						CPointer* pPtr = ExtractPointer(pyretval);
-						pHook->SetReturnValue<unsigned long>(pPtr->m_ulAddr);
+						pHook->SetReturnValue<unsigned long>(ExtractPointer(pyretval)->m_ulAddr);
 					} break;
 					case DATA_TYPE_STRING:		SetReturnValue<const char*>(pHook, pyretval); break;
 					default: BOOST_RAISE_EXCEPTION(PyExc_TypeError, "Unknown type.")
@@ -225,8 +224,7 @@ void CStackData::SetItem(unsigned int iIndex, object value)
 		case DATA_TYPE_DOUBLE:		SetArgument<double>(m_pHook, iIndex, value); break;
 		case DATA_TYPE_POINTER:
 		{
-			CPointer* pPtr = ExtractPointer(value);
-			SetArgument<unsigned long>(m_pHook, iIndex, object(pPtr->m_ulAddr));
+			SetArgument<unsigned long>(m_pHook, iIndex, object(ExtractPointer(value)->m_ulAddr));
 		} break;
 		case DATA_TYPE_STRING:		SetArgument<const char *>(m_pHook, iIndex, value); break;
 		default: BOOST_RAISE_EXCEPTION(PyExc_TypeError, "Unknown type.")

--- a/src/core/modules/memory/memory_pointer.cpp
+++ b/src/core/modules/memory/memory_pointer.cpp
@@ -125,8 +125,7 @@ void SetPtrHelper(unsigned long addr, unsigned long ptr)
 void CPointer::SetPtr(object oPtr, int iOffset /* = 0 */)
 {
 	Validate();
-	CPointer* pPtr = ExtractPointer(oPtr);
-	SetPtrHelper(m_ulAddr + iOffset, pPtr->m_ulAddr);
+	SetPtrHelper(m_ulAddr + iOffset, ExtractPointer(oPtr)->m_ulAddr);
 }
 
 int CompareHelper(void* first, void* second, unsigned long length)
@@ -140,18 +139,18 @@ int CompareHelper(void* first, void* second, unsigned long length)
 int CPointer::Compare(object oOther, unsigned long ulNum)
 {
 	Validate();
-	CPointer* pOther = ExtractPointer(oOther);
-	pOther->Validate();
-	return CompareHelper((void *) m_ulAddr, (void *) pOther->m_ulAddr, ulNum);
+	CPointer pOther = CPointer(ExtractPointer(oOther)->m_ulAddr);
+	pOther.Validate();
+	return CompareHelper((void *) m_ulAddr, (void *) pOther.m_ulAddr, ulNum);
 }
 
 bool CPointer::IsOverlapping(object oOther, unsigned long ulNumBytes)
 {
-	CPointer* pOther = ExtractPointer(oOther);
-	if (m_ulAddr <= pOther->m_ulAddr)
-		return m_ulAddr + ulNumBytes > pOther->m_ulAddr;
-       
-	return pOther->m_ulAddr + ulNumBytes > m_ulAddr;
+	unsigned long ulOther = ExtractPointer(oOther)->m_ulAddr;
+	if (m_ulAddr <= ulOther)
+		return m_ulAddr + ulNumBytes > ulOther;
+
+	return ulOther + ulNumBytes > m_ulAddr;
 }
 
 void* SearchBytesHelper(unsigned char* base, unsigned char* end, unsigned char* bytes, unsigned long length)
@@ -208,13 +207,13 @@ void CPointer::Copy(object oDest, unsigned long ulNumBytes)
 		BOOST_RAISE_EXCEPTION(PyExc_ValueError, "'num_bytes' must be greater than 0.")
 	}
 
-	CPointer* pDest = ExtractPointer(oDest);
-	pDest->Validate();
+	CPointer pDest = CPointer(ExtractPointer(oDest)->m_ulAddr);
+	pDest.Validate();
 
 	if (IsOverlapping(oDest, ulNumBytes))
 		BOOST_RAISE_EXCEPTION(PyExc_ValueError, "Pointers are overlapping!")
 
-	CopyHelper((void *) pDest->m_ulAddr, (void *) m_ulAddr, ulNumBytes);
+	CopyHelper((void *) pDest.m_ulAddr, (void *) m_ulAddr, ulNumBytes);
 }
 
 void MoveHelper(void* dest, void* source, unsigned long length)
@@ -231,9 +230,9 @@ void CPointer::Move(object oDest, unsigned long ulNumBytes)
 		BOOST_RAISE_EXCEPTION(PyExc_ValueError, "'num_bytes' must be greater than 0.")
 	}
 
-	CPointer* pDest = ExtractPointer(oDest);
-	pDest->Validate();
-	MoveHelper((void *) pDest->m_ulAddr, (void *) m_ulAddr, ulNumBytes);
+	CPointer pDest = CPointer(ExtractPointer(oDest)->m_ulAddr);
+	pDest.Validate();
+	MoveHelper((void *) pDest.m_ulAddr, (void *) m_ulAddr, ulNumBytes);
 }
 
 unsigned long GetVirtualFuncHelper(unsigned long addr, int index)

--- a/src/core/modules/memory/memory_pointer.cpp
+++ b/src/core/modules/memory/memory_pointer.cpp
@@ -125,7 +125,7 @@ void SetPtrHelper(unsigned long addr, unsigned long ptr)
 void CPointer::SetPtr(object oPtr, int iOffset /* = 0 */)
 {
 	Validate();
-	SetPtrHelper(m_ulAddr + iOffset, ExtractPointer(oPtr)->m_ulAddr);
+	SetPtrHelper(m_ulAddr + iOffset, ExtractAddress(oPtr));
 }
 
 int CompareHelper(void* first, void* second, unsigned long length)
@@ -139,14 +139,12 @@ int CompareHelper(void* first, void* second, unsigned long length)
 int CPointer::Compare(object oOther, unsigned long ulNum)
 {
 	Validate();
-	CPointer pOther = CPointer(ExtractPointer(oOther)->m_ulAddr);
-	pOther.Validate();
-	return CompareHelper((void *) m_ulAddr, (void *) pOther.m_ulAddr, ulNum);
+	return CompareHelper((void *) m_ulAddr, (void *) ExtractAddress(oOther, true), ulNum);
 }
 
 bool CPointer::IsOverlapping(object oOther, unsigned long ulNumBytes)
 {
-	unsigned long ulOther = ExtractPointer(oOther)->m_ulAddr;
+	unsigned long ulOther = ExtractAddress(oOther);
 	if (m_ulAddr <= ulOther)
 		return m_ulAddr + ulNumBytes > ulOther;
 
@@ -207,13 +205,10 @@ void CPointer::Copy(object oDest, unsigned long ulNumBytes)
 		BOOST_RAISE_EXCEPTION(PyExc_ValueError, "'num_bytes' must be greater than 0.")
 	}
 
-	CPointer pDest = CPointer(ExtractPointer(oDest)->m_ulAddr);
-	pDest.Validate();
-
 	if (IsOverlapping(oDest, ulNumBytes))
 		BOOST_RAISE_EXCEPTION(PyExc_ValueError, "Pointers are overlapping!")
 
-	CopyHelper((void *) pDest.m_ulAddr, (void *) m_ulAddr, ulNumBytes);
+	CopyHelper((void *) ExtractAddress(oDest, true), (void *) m_ulAddr, ulNumBytes);
 }
 
 void MoveHelper(void* dest, void* source, unsigned long length)
@@ -230,9 +225,7 @@ void CPointer::Move(object oDest, unsigned long ulNumBytes)
 		BOOST_RAISE_EXCEPTION(PyExc_ValueError, "'num_bytes' must be greater than 0.")
 	}
 
-	CPointer pDest = CPointer(ExtractPointer(oDest)->m_ulAddr);
-	pDest.Validate();
-	MoveHelper((void *) pDest.m_ulAddr, (void *) m_ulAddr, ulNumBytes);
+	MoveHelper((void *) ExtractAddress(oDest, true), (void *) m_ulAddr, ulNumBytes);
 }
 
 unsigned long GetVirtualFuncHelper(unsigned long addr, int index)

--- a/src/core/modules/memory/memory_tools.h
+++ b/src/core/modules/memory/memory_tools.h
@@ -33,8 +33,6 @@
 #include "memory_pointer.h"
 #include "memory_utilities.h"
 
-CPointer* ExtractPointer(object oPtr);
-
 
 // ============================================================================
 // >> GetObjectPointer
@@ -78,7 +76,20 @@ inline object MakeObject(object cls, CPointer *pPtr)
 
 inline object MakeObject(object cls, object oPtr)
 {
-	return MakeObject(cls, ExtractPointer(oPtr));
+	CPointer *pPtr;
+
+	extract<CPointer *> extractor(oPtr);
+	if (!extractor.check())
+	{
+		oPtr = oPtr.attr(GET_PTR_NAME)();
+		pPtr = extract<CPointer *>(oPtr);
+	}
+	else
+	{
+		pPtr = extractor();
+	}
+
+	return MakeObject(cls, pPtr);
 }
 
 

--- a/src/core/modules/memory/memory_tools.h
+++ b/src/core/modules/memory/memory_tools.h
@@ -76,18 +76,8 @@ inline object MakeObject(object cls, CPointer *pPtr)
 
 inline object MakeObject(object cls, object oPtr)
 {
-	CPointer *pPtr;
-
-	extract<CPointer *> extractor(oPtr);
-	if (!extractor.check())
-	{
-		oPtr = oPtr.attr(GET_PTR_NAME)();
-		pPtr = extract<CPointer *>(oPtr);
-	}
-	else
-	{
-		pPtr = extractor();
-	}
+	oPtr = oPtr.attr(GET_PTR_NAME)();
+	CPointer *pPtr = extract<CPointer *>(oPtr);
 
 	return MakeObject(cls, pPtr);
 }

--- a/src/core/modules/memory/memory_utilities.h
+++ b/src/core/modules/memory/memory_utilities.h
@@ -66,8 +66,10 @@
 inline CPointer* ExtractPointer(object oPtr)
 {
 	extract<CPointer *> extractor(oPtr);
-	if (!extractor.check())
-		return extract<CPointer *>(oPtr.attr(GET_PTR_NAME)());
+	if (!extractor.check()){
+		oPtr = oPtr.attr(GET_PTR_NAME)();
+		return extract<CPointer *>(oPtr);
+	}
 
 	return extractor();
 }

--- a/src/core/modules/memory/memory_utilities.h
+++ b/src/core/modules/memory/memory_utilities.h
@@ -61,17 +61,27 @@
 
 
 // ============================================================================
-// >> ExtractPointer
+// >> ExtractAddress
 // ============================================================================
-inline CPointer* ExtractPointer(object oPtr)
+inline unsigned long ExtractAddress(object oPtr, bool bValidate = false)
 {
+	CPointer* pPtr;
+
 	extract<CPointer *> extractor(oPtr);
-	if (!extractor.check()){
+	if (!extractor.check())
+	{
 		oPtr = oPtr.attr(GET_PTR_NAME)();
-		return extract<CPointer *>(oPtr);
+		pPtr = extract<CPointer *>(oPtr);
+	}
+	else
+	{
+		pPtr = extractor();
 	}
 
-	return extractor();
+	if (bValidate)
+		pPtr->Validate();
+
+	return pPtr->m_ulAddr;
 }
 
 


### PR DESCRIPTION
#334, #372, #373

When the object passed to ExtractPointer isn't the CPointer, the CPointer* generated by _ptr() will be released immediately.
Therefore, the CPointer* generated by ExtractPointer must not be retained.

The new Linux distributions have made this problem more apparent.