### PR TITLE
Split CEnvProjectedTexture data between different games.

### DIFF
--- a/addons/source-python/data/source-python/entities/CEnvProjectedTexture.ini
+++ b/addons/source-python/data/source-python/entities/CEnvProjectedTexture.ini
@@ -1,7 +1,5 @@
 [input]
 
-    always_update_off = AlwaysUpdateOff
-    always_update_on = AlwaysUpdateOn
     fov = FOV
     spotlight_texture = SpotlightTexture
     target = Target
@@ -12,29 +10,22 @@
 [keyvalue]
     
     ambient = ambient
-    brightness_scale = brightnessscale
     camera_space = cameraspace
-    color_transition_time = colortransitiontime
     enable_shadows = enableshadows
     far_z = farz
     light_fov = lightfov
     light_only_target = lightonlytarget
     light_world = lightworld
     near_z = nearz
-    projection_rotation = projection_rotation
-    projection_size = projection_size
     shadow_quality = shadowquality
-    simple_projection = simpleprojection
     texture_frame = textureframe
-    texture_name = texturename
 
+    [[light_color_string]]
+        name = lightcolor
+        type = STRING
 
 [property]
     
-    always_update = m_bAlwaysUpdate
     state = m_bState
     target_entity = m_hTargetEntity
-
-    [[light_color]]
-        name = m_LightColor
-        type = Color
+    texture_name = texturename

--- a/addons/source-python/data/source-python/entities/csgo/CEnvProjectedTexture.ini
+++ b/addons/source-python/data/source-python/entities/csgo/CEnvProjectedTexture.ini
@@ -1,0 +1,29 @@
+[input]
+
+    always_update_off = AlwaysUpdateOff
+    always_update_on = AlwaysUpdateOn
+    set_far_z = SetFarZ
+    set_light_style = SetLightStyle
+    set_near_z = SetNearZ
+    set_pattern = SetPattern
+
+
+[keyvalue]
+    
+    brightness_scale = brightnessscale
+    color_transition_time = colortransitiontime
+    default_style = defaultstyle
+    pattern = pattern
+    projection_rotation = projection_rotation
+    projection_size = projection_size
+    simple_projection = simpleprojection
+    style = style
+
+
+[property]
+    
+    always_update = m_bAlwaysUpdate
+
+    [[light_color]]
+        name = m_LightColor
+        type = Color

--- a/addons/source-python/data/source-python/entities/l4d2/CEnvProjectedTexture.ini
+++ b/addons/source-python/data/source-python/entities/l4d2/CEnvProjectedTexture.ini
@@ -1,0 +1,3 @@
+[property]
+    
+    linear_float_light_color = m_LinearFloatLightColor

--- a/addons/source-python/data/source-python/entities/orangebox/CEnvProjectedTexture.ini
+++ b/addons/source-python/data/source-python/entities/orangebox/CEnvProjectedTexture.ini
@@ -1,0 +1,3 @@
+[property]
+    
+    linear_float_light_color = m_LinearFloatLightColor


### PR DESCRIPTION
###### Continuation of #380 - due to me not testing the data properly (sorry @jordanbriere :sweat_smile:).
Tested the changes in HL2DM, CSS, and CSGO.
The only issue I ran into was the hardcoded [lightcolor](https://github.com/alliedmodders/hl2sdk/blob/hl2dm/game/server/env_projectedtexture.cpp#L158) keyvalue - setting the type as Color makes the data unusable: 
```
[SP] Caught an Exception:
Traceback (most recent call last):
  File "..\addons\source-python\packages\source-python\commands\auth.py", line 44, in __call__
    return self.callback(*args)
  File "..\addons\source-python\plugins\flashlight\flashlight.py", line 52, in inspect_weapon
    PlayerF(index).toggle_torch()
  File "..\addons\source-python\plugins\flashlight\flashlight.py", line 111, in toggle_torch
    owner_handle=self.inthandle
  File "..\addons\source-python\plugins\flashlight\flashlight.py", line 157, in create
    texture.light_color = color
  File "..\addons\source-python\packages\source-python\entities\_base.py", line 246, in __setattr__
    for server_class, instance in self.server_classes.items():
  File "..\addons\source-python\packages\source-python\entities\_base.py", line 231, in __getattr__
    raise AttributeError('Attribute "{0}" not found'.format(attr))

AttributeError: Attribute "server_classes" not found
```
This is quite odd as setting the same keyvalue with set_key_value_color() works fine. What am I doing wrong here?
For the time being, I renamed that keyvalue to light_color_string and set the type as STRING.

@satoon101 was correct about `m_LinearFloatLightColor` being the Orange Box/L4D2 equivalent of `m_LightColor` from CSGO, but it doesn't use the Color object. Instead it uses a Vector containing floats ranging from 0 to 1 (e.g. Vector(1, 0, 0) would be red).
