### PR TITLE
Fixed referencing of released m_pCallingConvention on Source.Python unload.

### DIFF
--- a/src/core/sp_main.cpp
+++ b/src/core/sp_main.cpp
@@ -370,9 +370,6 @@ bool CSourcePython::Load(	CreateInterfaceFn interfaceFactory, CreateInterfaceFn 
 void CSourcePython::Unload( void )
 {
 	Msg(MSG_PREFIX "Unloading...\n");
-	
-	DevMsg(1, MSG_PREFIX "Unhooking all functions...\n");
-	GetHookManager()->UnhookAllFunctions();
 
 #if defined(ENGINE_ORANGEBOX) || defined(ENGINE_BMS) || defined(ENGINE_GMOD)
 	if (m_pOldSpewOutputFunc)
@@ -387,9 +384,12 @@ void CSourcePython::Unload( void )
 
 	DevMsg(1, MSG_PREFIX "Resetting cache notifier...\n");
 	modelcache->SetCacheNotify(m_pOldMDLCacheNotifier);
-	
+
 	DevMsg(1, MSG_PREFIX "Shutting down python...\n");
 	g_PythonManager.Shutdown();
+
+	DevMsg(1, MSG_PREFIX "Unhooking all functions...\n");
+	GetHookManager()->UnhookAllFunctions();
 
 	DevMsg(1, MSG_PREFIX "Clearing all commands...\n");
 	ClearAllCommands();


### PR DESCRIPTION
UnhookAllFunctions releases all m_pCallingConventions, but CFunctions held by AutoUnload such as EntityPreHook are not yet released, causing segmentation fault.
https://github.com/Source-Python-Dev-Team/Source.Python/blob/89273cd840e601094f31ade3ef601ce3a95f012c/src/core/modules/memory/memory_function.cpp#L199
UnhookAllFunctions has been moved to the end to deal with this.