### PR TITLE
Fixed MemberFunction not returning the correct return type.

### DIFF
--- a/addons/source-python/packages/source-python/memory/helpers.py
+++ b/addons/source-python/packages/source-python/memory/helpers.py
@@ -316,10 +316,7 @@ class MemberFunction(Function):
     def __init__(self, manager, return_type, func, this):
         """Initialize the instance."""
         self._function = func
-        super().__init__(
-            func.address, func.convention, func.arguments,
-            func.return_type if func.converter is None else func.converter
-        )
+        super().__init__(func)
 
         # This should always hold a TypeManager instance
         self._manager = manager

--- a/addons/source-python/packages/source-python/memory/helpers.py
+++ b/addons/source-python/packages/source-python/memory/helpers.py
@@ -317,7 +317,8 @@ class MemberFunction(Function):
         """Initialize the instance."""
         self._function = func
         super().__init__(
-            func.address, func.convention, func.arguments, func.return_type
+            func.address, func.convention, func.arguments,
+            func.return_type if func.converter is None else func.converter
         )
 
         # This should always hold a TypeManager instance

--- a/src/core/modules/memory/memory_function.cpp
+++ b/src/core/modules/memory/memory_function.cpp
@@ -179,6 +179,29 @@ CFunction::CFunction(unsigned long ulAddr, Convention_t eCallingConvention,
 	m_oConverter = oConverter;
 }
 
+CFunction::CFunction(const CFunction& obj)
+	:CPointer(obj)
+{
+	m_tArgs = obj.m_tArgs;
+	m_eReturnType = obj.m_eReturnType;
+	m_oConverter = obj.m_oConverter;
+
+	m_eCallingConvention = obj.m_eCallingConvention;
+	m_iCallingConvention = obj.m_iCallingConvention;
+
+	if (m_eCallingConvention != CONV_CUSTOM)
+	{
+		m_pCallingConvention = MakeDynamicHooksConvention(m_eCallingConvention, ObjectToDataTypeVector(m_tArgs), m_eReturnType);
+		m_oCallingConvention = object();
+	}
+	else
+	{
+		m_pCallingConvention = obj.m_pCallingConvention;
+		m_oCallingConvention = obj.m_oCallingConvention;
+		Py_INCREF(m_oCallingConvention.ptr());
+	}
+}
+
 CFunction::~CFunction()
 {
 	if (!m_pCallingConvention)

--- a/src/core/modules/memory/memory_function.h
+++ b/src/core/modules/memory/memory_function.h
@@ -53,12 +53,14 @@ enum Convention_t
 // ============================================================================
 // >> CFunction
 // ============================================================================
-class CFunction: public CPointer, private boost::noncopyable
+class CFunction: public CPointer
 {
 public:
 	CFunction(unsigned long ulAddr, object oCallingConvention, object oArgs, object oReturnType);
 	CFunction(unsigned long ulAddr, Convention_t eCallingConvention, int iCallingConvention,
 		boost::python::tuple tArgs, DataType_t eReturnType, object oConverter);
+
+	CFunction(const CFunction& obj);
 
 	~CFunction();
 
@@ -105,7 +107,6 @@ public:
 
 	// DynamicHooks calling convention (built-in and custom)
 	ICallingConvention*		m_pCallingConvention;
-	bool					m_bAllocatedCallingConvention;
 
 	// Custom calling convention
 	object					m_oCallingConvention;

--- a/src/core/modules/memory/memory_wrap.cpp
+++ b/src/core/modules/memory/memory_wrap.cpp
@@ -453,9 +453,9 @@ void export_type_info_iter(scope _memory)
 // ============================================================================
 void export_function(scope _memory)
 {
-	class_<CFunction, bases<CPointer>, boost::noncopyable >("Function", init<unsigned long, object, object, object>())
-		// Don't allow copies, because they will hold references to our calling convention.
-		// .def(init<CFunction&>())
+	class_<CFunction, bases<CPointer> >("Function", init<unsigned long, object, object, object>())
+		.def(init<CFunction&>())
+
 		.def("__call__",
 			raw_method(&CFunction::Call),
 			"Calls the function dynamically."


### PR DESCRIPTION
If the Function has a converter, then the MemberFunction must also have a correct converter.