### PR TITLE
Partial fix for issue #390.

### DIFF
--- a/addons/source-python/packages/source-python/messages/hooks.py
+++ b/addons/source-python/packages/source-python/messages/hooks.py
@@ -186,14 +186,7 @@ if UserMessage.is_protobuf():
             buffer = make_object(ProtobufMessage, args[3])
         except RuntimeError:
             # Patch for issue #390 - UserMessage was created by another plugin.
-            buffer = UserMessage(
-                _recipients, get_message_name(message_index)).buffer
-            buffer_ptr = get_object_pointer(buffer)
-            buffer_size = get_size(buffer)
-
-            orig_buffer_ptr = args[3]
-            orig_buffer_ptr.copy(buffer_ptr, buffer_size)
-            buffer_ptr.copy(orig_buffer_ptr, buffer_size)
+            buffer = ProtobufMessage.from_abstract_pointer(args[3])
 
         protobuf_user_message_hooks.notify(_recipients, buffer)
 


### PR DESCRIPTION
This fixes the hooks from not getting called when the UserMessage was created/sent by a third-party plugin (SourceMod), but I'm not sure how to retrieve the actual UserMessage data (e.g. [ShowMenu data](https://github.com/Source-Python-Dev-Team/Source.Python/blob/35d34c885b2d787b265c99930d0fe09f5534668d/addons/source-python/packages/source-python/messages/impl.py#L181)).