### PR TITLE
Changed to allow memory.manager to read Hex values.

### DIFF
--- a/addons/source-python/packages/source-python/memory/helpers.py
+++ b/addons/source-python/packages/source-python/memory/helpers.py
@@ -161,7 +161,10 @@ class Key(object):
     @staticmethod
     def as_int(manager, value):
         """Convert the value to an integer."""
-        return int(value)
+        try:
+            return int(value)
+        except ValueError:
+            return int(value, 16)
 
 
 # =============================================================================


### PR DESCRIPTION
I think this is useful for copying hex value directly from disassembler for offsets.