### PR TITLE
Changed SayText to accept optional colors.

### DIFF
--- a/addons/source-python/packages/source-python/messages/base.py
+++ b/addons/source-python/packages/source-python/messages/base.py
@@ -272,15 +272,18 @@ class SayText2(UserMessageCreator):
 
     def __init__(
             self, message, index=0, chat=False,
-            param1='', param2='', param3='', param4=''):
+            param1='', param2='', param3='', param4='',
+            color=(' \x01' if UserMessage.is_protobuf() else '\x01')):
         """Initialize the SayText2 instance."""
         super().__init__(
             message=message, index=index, chat=chat,
             param1=param1, param2=param2, param3=param3, param4=param4)
 
+        super(AttrDict, self).__setattr__("color", color)
+
     def protobuf(self, buffer, kwargs):
         """Send the SayText2 with protobuf."""
-        buffer.set_string('msg_name', ' \x01' + kwargs.message)
+        buffer.set_string('msg_name', self.color + kwargs.message)
         buffer.set_bool('chat', kwargs.chat)
         buffer.set_int32('ent_idx', kwargs.index)
         buffer.add_string('params', kwargs.param1)
@@ -293,7 +296,7 @@ class SayText2(UserMessageCreator):
         """Send the SayText2 with bitbuf."""
         buffer.write_byte(kwargs.index)
         buffer.write_byte(kwargs.chat)
-        buffer.write_string('\x01' + kwargs.message)
+        buffer.write_string(self.color + kwargs.message)
         buffer.write_string(kwargs.param1)
         buffer.write_string(kwargs.param2)
         buffer.write_string(kwargs.param3)
@@ -326,20 +329,24 @@ class SayText(UserMessageCreator):
     translatable_fields = ['message']
     reliable = True
 
-    def __init__(self, message, index=0, chat=False):
+    def __init__(
+            self, message, index=0, chat=False,
+            color=(' \x01' if UserMessage.is_protobuf() else '\x01')):
         """Initialize the SayText instance."""
         super().__init__(message=message, index=index, chat=chat)
+
+        super(AttrDict, self).__setattr__("color", color)
 
     def protobuf(self, buffer, kwargs):
         """Send the SayText with protobuf."""
         buffer.set_int32('ent_idx', kwargs.index)
         buffer.set_bool('chat', kwargs.chat)
-        buffer.set_string('text', ' \x01' + kwargs.message)
+        buffer.set_string('text', self.color + kwargs.message)
 
     def bitbuf(self, buffer, kwargs):
         """Send the SayText with bitbuf."""
         buffer.write_byte(kwargs.index)
-        buffer.write_string('\x01' + kwargs.message)
+        buffer.write_string(self.color + kwargs.message)
         buffer.write_byte(kwargs.chat)
 
 


### PR DESCRIPTION
This makes it possible to use chat format with SayText and send messages to the console without whitespace at the beginning.

```python
#   Commands
from commands import CommandReturn
from commands.say import SayFilter
#   Core
from core import PLATFORM
#   Engines
from engines.gamerules import find_game_rules
#   Memory
from memory import Convention
from memory import DataType
from memory import find_binary
from memory.hooks import HookType
#   Messages
from messages import SayText2
#   Players
from players.entity import Player


server = find_binary("server", srv_check=False)

# CS:GO
if PLATFORM == "linux":
    signature = b"\x55\x89\xE5\x83\xEC\x18\x89\x5D\xF8\x8B\x5D\x10\x89\x75\xFC\x0F\xB6\x45\x0C"
else:
    signature = b"\x55\x8B\xEC\x53\x57\x8B\x7D\x0C\x8B\xD9\x85\xFF\x75\x2A\x5F"

# char const * CCSGameRules::GetChatFormat( bool bTeamOnly, CBasePlayer * pPlayer )
get_chat_format = server[signature].make_function(
    Convention.CDECL, (
        DataType.POINTER,
        DataType.BOOL,
        DataType.POINTER,
    ),
    DataType.STRING,
)


@SayFilter
def on_say(command, index, team_only):
    player = Player(index)
    chat_format = get_chat_format(find_game_rules(), team_only, player)
    string = command.command_string
    SayText2(chat_format, index=index, chat=True, param1=player.name, param2=string).send() # Old
    SayText2(chat_format, index=index, chat=True, param1=player.name, param2=string, color="").send() # New
    SayText2(string, index=index, chat=True, color=('\u200b'+'\x01')).send() # New
    return CommandReturn.BLOCK
```
![saytextcolor](https://user-images.githubusercontent.com/30329245/130828761-8f75d294-499d-4b7f-a2d2-ee24dffe61c5.png)