### PR TITLE
Moved on_convar_changed_listener_manager to C++.

### DIFF
--- a/addons/source-python/packages/source-python/listeners/__init__.py
+++ b/addons/source-python/packages/source-python/listeners/__init__.py
@@ -21,7 +21,6 @@ from core.version import is_unversioned
 from core.version import VERSION
 #   Cvars
 from cvars import ConVar
-from cvars import cvar
 #   Engines
 from engines.server import server_game_dll
 #   Entities
@@ -52,6 +51,7 @@ from _listeners import on_client_disconnect_listener_manager
 from _listeners import on_client_fully_connect_listener_manager
 from _listeners import on_client_put_in_server_listener_manager
 from _listeners import on_client_settings_changed_listener_manager
+from _listeners import on_convar_changed_listener_manager
 from _listeners import on_level_init_listener_manager
 from _listeners import on_level_shutdown_listener_manager
 from _listeners import on_network_id_validated_listener_manager
@@ -166,7 +166,6 @@ __all__ = ('ButtonStatus',
 listeners_logger = _sp_logger.listeners
 
 on_version_update_listener_manager = ListenerManager()
-on_convar_changed_listener_manager = ListenerManager()
 on_plugin_loaded_manager = ListenerManager()
 on_plugin_unloaded_manager = ListenerManager()
 on_plugin_loading_manager = ListenerManager()
@@ -598,14 +597,6 @@ def _on_level_shutdown():
 
     # Make sure we don't get called more than once per map change
     OnLevelEnd._level_initialized = False
-
-
-@PreHook(get_virtual_function(cvar, 'CallGlobalChangeCallbacks'))
-def _pre_call_global_change_callbacks(args):
-    """Called when a ConVar has been changed."""
-    convar = make_object(ConVar, args[1])
-    old_value = args[2]
-    on_convar_changed_listener_manager.notify(convar, old_value)
 
 
 def _pre_fire_output(args):

--- a/src/core/modules/listeners/listeners_manager.cpp
+++ b/src/core/modules/listeners/listeners_manager.cpp
@@ -173,7 +173,7 @@ void CListenerManager::clear()
 //-----------------------------------------------------------------------------
 void ConVarChangedCallback(IConVar* var, const char* pOldValue, float flOldValue)
 {
-	CConVarChangedListenerManager* on_convar_changed_listener_manager = GetOnConVarChangedListenerManager();
+	static CConVarChangedListenerManager* on_convar_changed_listener_manager = GetOnConVarChangedListenerManager();
 	CALL_LISTENERS_WITH_MNGR(on_convar_changed_listener_manager, ptr(static_cast<ConVar*>(var)), pOldValue);
 }
 

--- a/src/core/modules/listeners/listeners_manager.cpp
+++ b/src/core/modules/listeners/listeners_manager.cpp
@@ -31,6 +31,18 @@
 
 
 //-----------------------------------------------------------------------------
+// External variables.
+//-----------------------------------------------------------------------------
+extern ICvar* g_pCVar;
+
+
+//-----------------------------------------------------------------------------
+// Extern functions
+//-----------------------------------------------------------------------------
+extern CConVarChangedListenerManager* GetOnConVarChangedListenerManager();
+
+
+//-----------------------------------------------------------------------------
 // Adds a callable to the end of the CListenerManager vector.
 //-----------------------------------------------------------------------------
 void CListenerManager::RegisterListener(PyObject* pCallable)
@@ -149,7 +161,38 @@ object CListenerManager::__getitem__(unsigned int index)
 
 void CListenerManager::clear()
 {
-	m_vecCallables.RemoveAll();
+	if (GetCount()) {
+		m_vecCallables.RemoveAll();
+		Finalize();
+	}
+}
+
+
+//-----------------------------------------------------------------------------
+// Convar changed callback.
+//-----------------------------------------------------------------------------
+void ConVarChangedCallback(IConVar* var, const char* pOldValue, float flOldValue)
+{
+	CConVarChangedListenerManager* on_convar_changed_listener_manager = GetOnConVarChangedListenerManager();
+	CALL_LISTENERS_WITH_MNGR(on_convar_changed_listener_manager, ptr(static_cast<ConVar*>(var)), pOldValue);
+}
+
+
+//-----------------------------------------------------------------------------
+// Called when the first callback is being registered.
+//-----------------------------------------------------------------------------
+void CConVarChangedListenerManager::Initialize()
+{
+	g_pCVar->InstallGlobalChangeCallback(ConVarChangedCallback);
+}
+
+
+//-----------------------------------------------------------------------------
+// Called when the last callback is being unregistered.
+//-----------------------------------------------------------------------------
+void CConVarChangedListenerManager::Finalize()
+{
+	g_pCVar->RemoveGlobalChangeCallback(ConVarChangedCallback);
 }
 
 

--- a/src/core/modules/listeners/listeners_manager.h
+++ b/src/core/modules/listeners/listeners_manager.h
@@ -33,6 +33,11 @@
 #include "utilities/wrap_macros.h"
 #include "utlvector.h"
 
+// This is required for accessing m_nFlags without patching convar.h
+#define private public
+#include "convar.h"
+#undef private
+
 
 //-----------------------------------------------------------------------------
 // Helper macros.
@@ -96,6 +101,17 @@ public:
 
 public:
 	CUtlVector<object> m_vecCallables;
+};
+
+
+//-----------------------------------------------------------------------------
+// CConVarChangedListenerManager class.
+//-----------------------------------------------------------------------------
+class CConVarChangedListenerManager: public CListenerManager
+{
+public:
+	virtual void Initialize();
+	virtual void Finalize();
 };
 
 

--- a/src/core/modules/listeners/listeners_manager.h
+++ b/src/core/modules/listeners/listeners_manager.h
@@ -33,10 +33,7 @@
 #include "utilities/wrap_macros.h"
 #include "utlvector.h"
 
-// This is required for accessing m_nFlags without patching convar.h
-#define private public
 #include "convar.h"
-#undef private
 
 
 //-----------------------------------------------------------------------------

--- a/src/core/modules/listeners/listeners_wrap.cpp
+++ b/src/core/modules/listeners/listeners_wrap.cpp
@@ -65,6 +65,12 @@ DEFINE_MANAGER_ACCESSOR(OnServerOutput)
 DEFINE_MANAGER_ACCESSOR(OnPlayerRunCommand)
 DEFINE_MANAGER_ACCESSOR(OnButtonStateChanged)
 
+static CConVarChangedListenerManager s_OnConVarChanged;
+CConVarChangedListenerManager* GetOnConVarChangedListenerManager()
+{
+	return &s_OnConVarChanged;
+}
+
 
 //-----------------------------------------------------------------------------
 // Forward declarations.
@@ -141,6 +147,8 @@ void export_listener_managers(scope _listeners)
 	_listeners.attr("on_client_fully_connect_listener_manager") = object(ptr(GetOnClientFullyConnectListenerManager()));
 	_listeners.attr("on_client_put_in_server_listener_manager") = object(ptr(GetOnClientPutInServerListenerManager()));
 	_listeners.attr("on_client_settings_changed_listener_manager") = object(ptr(GetOnClientSettingsChangedListenerManager()));
+
+	_listeners.attr("on_convar_changed_listener_manager") = object(ptr((CListenerManager *)GetOnConVarChangedListenerManager()));
 
 	_listeners.attr("on_level_init_listener_manager") = object(ptr(GetOnLevelInitListenerManager()));
 	_listeners.attr("on_level_shutdown_listener_manager") = object(ptr(GetOnLevelShutdownListenerManager()));

--- a/src/core/sp_main.cpp
+++ b/src/core/sp_main.cpp
@@ -111,6 +111,7 @@ extern ICvar* g_pCVar;
 extern void InitCommands();
 extern void ClearAllCommands();
 extern PLUGIN_RESULT DispatchClientCommand(edict_t *pEntity, const CCommand &command);
+extern CConVarChangedListenerManager* GetOnConVarChangedListenerManager();
 
 //-----------------------------------------------------------------------------
 // The plugin is a static singleton that is exported as an interface
@@ -396,6 +397,9 @@ void CSourcePython::Unload( void )
 
 	DevMsg(1, MSG_PREFIX "Shutting down python...\n");
 	g_PythonManager.Shutdown();
+
+	DevMsg(1, MSG_PREFIX "Clearing convar changed listener...\n");
+	GetOnConVarChangedListenerManager()->clear();
 
 	DevMsg(1, MSG_PREFIX "Unhooking all functions...\n");
 	GetHookManager()->UnhookAllFunctions();


### PR DESCRIPTION
Improved performance and eliminated hooks.

As a backwards compatibility break, when `CallGlobalChangeCallbacks` is blocked, the listener will no longer be emitted, but I don't think this will have any impact.

If there is a problem, I will reset to the hook.