### PR TITLE
Fixed a problem with Boolean in CFunction::Call.

### DIFF
--- a/src/core/modules/memory/memory_function.cpp
+++ b/src/core/modules/memory/memory_function.cpp
@@ -259,6 +259,15 @@ void CallHelperVoid(DCCallVM* vm, unsigned long addr)
 	EXCEPT_SEGV()
 }
 
+bool CallHelperBool(DCCallVM* vm, unsigned long addr)
+{
+	bool result;
+	TRY_SEGV()
+		result = dcCallBool(vm, addr) & 1;
+	EXCEPT_SEGV()
+	return result;
+}
+
 object CFunction::Call(tuple args, dict kw)
 {
 	if (!IsCallable())
@@ -309,7 +318,7 @@ object CFunction::Call(tuple args, dict kw)
 	switch(m_eReturnType)
 	{
 		case DATA_TYPE_VOID:		CallHelperVoid(g_pCallVM, m_ulAddr); break;
-		case DATA_TYPE_BOOL:		return object(CallHelper<bool>(dcCallBool, g_pCallVM, m_ulAddr));
+		case DATA_TYPE_BOOL:		return object(CallHelperBool(g_pCallVM, m_ulAddr));
 		case DATA_TYPE_CHAR:		return object(CallHelper<char>(dcCallChar, g_pCallVM, m_ulAddr));
 		case DATA_TYPE_UCHAR:		return object(CallHelper<unsigned char>(dcCallChar, g_pCallVM, m_ulAddr));
 		case DATA_TYPE_SHORT:		return object(CallHelper<short>(dcCallShort, g_pCallVM, m_ulAddr));

--- a/src/core/modules/memory/memory_function.cpp
+++ b/src/core/modules/memory/memory_function.cpp
@@ -259,15 +259,6 @@ void CallHelperVoid(DCCallVM* vm, unsigned long addr)
 	EXCEPT_SEGV()
 }
 
-bool CallHelperBool(DCCallVM* vm, unsigned long addr)
-{
-	bool result;
-	TRY_SEGV()
-		result = dcCallBool(vm, addr) & 1;
-	EXCEPT_SEGV()
-	return result;
-}
-
 object CFunction::Call(tuple args, dict kw)
 {
 	if (!IsCallable())
@@ -318,7 +309,7 @@ object CFunction::Call(tuple args, dict kw)
 	switch(m_eReturnType)
 	{
 		case DATA_TYPE_VOID:		CallHelperVoid(g_pCallVM, m_ulAddr); break;
-		case DATA_TYPE_BOOL:		return object(CallHelperBool(g_pCallVM, m_ulAddr));
+		case DATA_TYPE_BOOL:		return object(CallHelper<bool>(dcCallBool, g_pCallVM, m_ulAddr));
 		case DATA_TYPE_CHAR:		return object(CallHelper<char>(dcCallChar, g_pCallVM, m_ulAddr));
 		case DATA_TYPE_UCHAR:		return object(CallHelper<unsigned char>(dcCallChar, g_pCallVM, m_ulAddr));
 		case DATA_TYPE_SHORT:		return object(CallHelper<short>(dcCallShort, g_pCallVM, m_ulAddr));

--- a/src/thirdparty/dyncall/include/dyncall_config.h
+++ b/src/thirdparty/dyncall/include/dyncall_config.h
@@ -38,7 +38,7 @@
 
 #include "dyncall_macros.h"
 
-#define DC_BOOL         int
+#define DC_BOOL         bool
 #define DC_LONG_LONG    long long
 #define DC_POINTER      unsigned long
 


### PR DESCRIPTION
When testing is_in_field_of_view(#417), the results were incorrect(#316), so I looked into it and found that the boolean was judging the whole value of eax (e.g. -27648 was True), which seems to be giving incorrect results.


I don't think this will break any existing plugins, but I can't be sure.

Test Code:
```python
#   Memory
from memory import Convention
from memory import DataType
#   Players
from players.entity import Player

player = Player(1)
player2 = Player(2)

is_in_field_of_view  = player.make_virtual_function(
    276,
    Convention.THISCALL, (
        DataType.POINTER,
        DataType.POINTER,
    ),
    DataType.INT
)

print(player.is_in_field_of_view(player2.origin))
print(is_in_field_of_view(player, player2.origin) & 1)
print("int is_in_field_of_view", is_in_field_of_view(player, player2.origin))
```