### PR TITLE
 Added the ability to add callbacks to ConVar that will be called when ConVar is changed.

### DIFF
--- a/addons/source-python/packages/source-python/cvars/__init__.py
+++ b/addons/source-python/packages/source-python/cvars/__init__.py
@@ -6,6 +6,8 @@
 # >> IMPORTS
 # =============================================================================
 # Source.Python Imports
+#   Core
+from core import AutoUnload
 #   Cvars
 from _cvars import ConVar
 from _cvars import _Cvar
@@ -24,5 +26,64 @@ from _cvars import cvar
 # >> ALL DECLARATION
 # =============================================================================
 __all__ = ('ConVar',
+           'ConVarChanged',
            'cvar',
            )
+
+
+# =============================================================================
+# >> CLASSES
+# =============================================================================
+class ConVarChanged(AutoUnload):
+    """ConVarChanged decorator class."""
+
+    def __init__(self, *convars):
+        """Store the convars."""
+        self._convars = ()
+        self.callback = None
+
+        # Validate convars
+        if not convars:
+            raise ValueError('At least one convar is required.')
+
+        _convars = []
+        for convar in convars:
+            if not isinstance(convar, (str, ConVar)):
+                raise ValueError('Given convar is not ConVar or ConVar name.')
+
+            elif isinstance(convar, str):
+                convar_name = convar
+                convar = cvar.find_var(convar_name)
+                if convar is None:
+                    raise ValueError(
+                        f'"{convar_name}" is not a valid ConVar name.')
+
+            _convars.append(convar)
+
+        self._convars = tuple(_convars)
+
+    def __call__(self, callback):
+        """Store the callback and add it to convars."""
+        # Store the callback
+        self.callback = callback
+
+        # Loop through all convars
+        for convar in self._convars:
+
+            # Add the callback
+            convar.add_changed_callback(self.callback)
+
+        # Return the callback
+        return self.callback
+
+    def _unload_instance(self):
+        """Remove the callback from convars."""
+        # Was no callback registered?
+        if self.callback is None:
+            return
+
+        # Loop through all convars
+        for convar in self._convars:
+
+            # Remove the callback
+            convar.remove_changed_callback(self.callback)

--- a/src/core/modules/cvars/cvars_wrap.cpp
+++ b/src/core/modules/cvars/cvars_wrap.cpp
@@ -46,6 +46,12 @@ extern ICvar* g_pCVar;
 
 
 //-----------------------------------------------------------------------------
+// ConVar extension definition.
+//-----------------------------------------------------------------------------
+bool ConVarExt::installed = false;
+
+
+//-----------------------------------------------------------------------------
 // Forward declarations.
 //-----------------------------------------------------------------------------
 void export_cvar_interface(scope);
@@ -299,7 +305,19 @@ void export_convar(scope _cvars)
 			&ConVarExt::RemovePublic,
 			"Remove the notify flag and make the console variable no longer public."
 		)
-			
+
+		.def("add_changed_callback",
+			&ConVarExt::AddChangedCallback,
+			"Add a callable object that will be called when the ConVar is changed.",
+			args("callable")
+		)
+
+		.def("remove_changed_callback",
+			&ConVarExt::RemoveChangedCallback,
+			"Remove a callable object that will be called when the ConVar is changed.",
+			args("callable")
+		)
+
 		// Special methods...
 		.def("__float__",
 			&ConVar::GetFloat,


### PR DESCRIPTION
There is already `OnConVarChanged`, but it is wasteful if you only want to know the changes of a specific ConVar.
This was made to match SourceMod's AddChangeHook feature.
https://wiki.alliedmods.net/ConVars_(SourceMod_Scripting)#Change_Callbacks

Code:
```python
# Cvars
from cvars import ConVar
from cvars import ConVarChanged


@ConVarChanged(ConVar("test", "1", "test convar."))
def on_test_changed(convar, old_value, new_value):
    print("ConVar changed.")
    print(f"    Name: {convar.name}\n" \
          f"    Old Value: {old_value}\n" \
          f"    New Value: {new_value}\n")

test2 = ConVar("test2", "999", "test2 convar.")
test3 = ConVar("test3", "999", "test3 convar.")

@ConVarChanged(test2, "test3")
def on_test2_test3_changed(convar, old_value, new_value):
    convar.set_int(999)
```

Output:
```
test 0
ConVar changed.
    Name: test
    Old Value: 1
    New Value: 0

test2 0
test3 1000

test2
"test2" = "999" - test2 convar.
test3
"test3" = "999" - test3 convar.
```