### PR TITLE
Fixed the deletion of ConVar/ConCommand not managed by Source.Python.

### DIFF
--- a/src/core/sp_main.cpp
+++ b/src/core/sp_main.cpp
@@ -409,9 +409,6 @@ void CSourcePython::Unload( void )
 	DevMsg(1, MSG_PREFIX "Clearing all commands...\n");
 	ClearAllCommands();
 
-	DevMsg(1, MSG_PREFIX "Unregistering ConVar...\n");
-	ConVar_Unregister( );
-
 	// New in CSGO...
 #if defined(ENGINE_CSGO) || defined(ENGINE_BLADE)
 	DevMsg(1, MSG_PREFIX "Disconnecting interfaces...\n");


### PR DESCRIPTION
The function ConVar_Unregister unregisters all ConVar/ConCommand and should not be used.

Output:
```
plugin_print
Loaded plugins:
---------------------
0:      "Source.Python, (C) 2012-2021, Source.Python Team."
1:      "Metamod:Source 1.11.0-dev+1145"
---------------------

meta version
 Metamod:Source Version Information
    Metamod:Source version 1.11.0-dev+1145
    Plugin interface version: 16:14
    SourceHook version: 5:5
    Loaded As: Valve Server Plugin
    Compiled on: Jul 11 2021 22:32:15
    Built from: https://github.com/alliedmodders/metamod-source/commit/0bb53f2
    Build ID: 1145:0bb53f2
    http://www.metamodsource.net/

plugin_unload sourcepython
[Source.Python] Unloading...
[Source.Python] Unloaded successfully.
Unloaded plugin "sourcepython"

plugin_print
Loaded plugins:
---------------------
0:      "Metamod:Source 1.11.0-dev+1145"
---------------------

meta version
Unknown command "meta"
```
to
```
plugin_unload sourcepython
[Source.Python] Unloading...
[Source.Python] Unloaded successfully.
Unloaded plugin "sourcepython"

plugin_print
Loaded plugins:
---------------------
0:      "Metamod:Source 1.11.0-dev+1145"
---------------------

meta version
 Metamod:Source Version Information
    Metamod:Source version 1.11.0-dev+1145
    Plugin interface version: 16:14
    SourceHook version: 5:5
    Loaded As: Valve Server Plugin
    Compiled on: Jul 11 2021 22:32:15
    Built from: https://github.com/alliedmodders/metamod-source/commit/0bb53f2
    Build ID: 1145:0bb53f2
    http://www.metamodsource.net/
```