### PR TITLE
Fixed an issue with certain weapons restrictions not working properly.

### DIFF
--- a/addons/source-python/packages/source-python/weapons/restrictions.py
+++ b/addons/source-python/packages/source-python/weapons/restrictions.py
@@ -386,7 +386,9 @@ weapon_restriction_handler = WeaponRestrictionHandler()
 def _on_weapon_bump(args):
     """Return whether the player is allowed to pickup the weapon."""
     return weapon_restriction_manager.on_player_bumping_weapon(
-        make_object(Player, args[0]), edict_from_pointer(args[1]).classname)
+        make_object(Player, args[0]),
+        make_object(Weapon, args[1]).weapon_name
+    )
 
 
 if GAME_NAME in ('cstrike', 'csgo'):


### PR DESCRIPTION
Classname of a certain weapons cannot be obtained by normal way.

https://developer.valvesoftware.com/wiki/Weapon_cz75a

> weapon_cz75a is a point entity available in Counter-Strike: Global Offensive .
> Warning: In the I/O system and in VScript, this entity is targeted with the classname weapon_p250 instead!

Code:
```python
#   Weapons
from weapons.entity import Weapon

weapon_entity = Weapon.create("weapon_cz75a")

print("Weapon ClassName: ", weapon_entity.weapon_name)
print("Edict ClassName: ", weapon_entity.edict.classname)
```

Output:
```
Weapon ClassName:  weapon_cz75a
Edict ClassName:  weapon_p250
```