### PR TITLE
Updated projectile data for CS:GO.

### DIFF
--- a/addons/source-python/data/source-python/entities/csgo/CDecoyProjectile.ini
+++ b/addons/source-python/data/source-python/entities/csgo/CDecoyProjectile.ini
@@ -5,6 +5,5 @@ srv_check = False
 
     # CDecoyProjectile::Think_Detonate
     [[detonate]]
-        # TODO
         identifier_windows = 55 8B EC 51 56 8B F1 57 8B 86 D4 00 00 00
-        identifier_linux = 55 89 E5 57 56 53 83 EC 3C 8B 5D 08 F6 83 DD 00 00 00 10
+        identifier_linux = 55 89 E5 57 56 53 83 EC 3C 8B 5D 08 F6 83 2A 00 00 00 10

--- a/addons/source-python/data/source-python/entities/csgo/CFlashbangProjectile.ini
+++ b/addons/source-python/data/source-python/entities/csgo/CFlashbangProjectile.ini
@@ -5,8 +5,8 @@ srv_check = False
 
     # _ZN20CFlashbangProjectile8DetonateEv
     [[detonate]]
-        offset_linux = 238
-        offset_windows = 237
+        offset_linux = 239
+        offset_windows = 238
 
 
 [input]

--- a/addons/source-python/data/source-python/entities/csgo/CHEGrenadeProjectile.ini
+++ b/addons/source-python/data/source-python/entities/csgo/CHEGrenadeProjectile.ini
@@ -5,8 +5,8 @@ srv_check = False
 
     # _ZN20CHEGrenadeProjectile8DetonateEv
     [[detonate]]
-        offset_linux = 238
-        offset_windows = 237
+        offset_linux = 239
+        offset_windows = 238
 
 
 [input]

--- a/addons/source-python/data/source-python/entities/csgo/CMolotovProjectile.ini
+++ b/addons/source-python/data/source-python/entities/csgo/CMolotovProjectile.ini
@@ -5,8 +5,8 @@ srv_check = False
 
     # _ZN18CMolotovProjectile8DetonateEv
     [[detonate]]
-        offset_linux = 238
-        offset_windows = 237
+        offset_linux = 239
+        offset_windows = 238
 
 
 [input]

--- a/addons/source-python/data/source-python/entities/csgo/CSensorGrenadeProjectile.ini
+++ b/addons/source-python/data/source-python/entities/csgo/CSensorGrenadeProjectile.ini
@@ -4,12 +4,12 @@ srv_check = False
 [function]
 
     # CSensorGrenadeProjectile::Think_Arm
-    [[detonate]]
+    [[start_timer]]
         identifier_windows = 56 8B F1 57 8B 86 D4 00 00 00 C1 E8 0C A8 01 74 2A E8 2A 2A 2A 2A F3 0F 10 86 80 01 00 00 F3 0F 10 96 7C 01 00 00 F3 0F 10 8E 84 01 00 00 F3 0F 59 D2 F3 0F 59 C0 F3 0F 59 C9 F3 0F 58 D0 F3 0F 58 D1 F3 0F 10 0D 2A 2A 2A 2A 0F 28 C2 F3 0F 51 C0 0F 2F C1 76 2A 8B 0D 2A 2A 2A 2A F3 0F 10 41 10 F3 0F 58 C1 0F 2E 05 2A 2A 2A 2A 9F F6 C4 44 7A 2A 83 CF FF EB 2A F3 0F 5E 41 20 F3 0F 58 05 2A 2A 2A 2A F3 0F 2C F8 39 BE A4 00 00 00 8D 96 A4 00 00 00 74 2A 8B 82 5C FF FF FF 8D 8A 5C FF FF FF 52 FF 90 D4 00 00 00 89 BE A4 00 00 00 83 FF FF 8B CE 0F 95 C0 0F B6 C0 50 E8 2A 2A 2A 2A 5F 5E C3
         identifier_linux = 55 89 E5 53 83 EC 34 8B 5D 08 F6 83 2A 00 00 00 10
 
     # CSensorGrenadeProjectile::SensorThink
-    [[sensor_think]]
+    [[detonate]]
         identifier_windows = 55 8B EC 83 E4 F8 51 53 56 57 8B F1 E8 2A 2A 2A 2A 8B F8
         identifier_linux = 55 89 E5 57 56 53 83 EC 3C 8B 5D 08 89 1C 24 E8 2A 2A 2A 2A 85 C0
 

--- a/addons/source-python/data/source-python/entities/csgo/CSensorGrenadeProjectile.ini
+++ b/addons/source-python/data/source-python/entities/csgo/CSensorGrenadeProjectile.ini
@@ -3,8 +3,25 @@ srv_check = False
 
 [function]
 
-    # CSensorGrenadeProjectile::Think_Detonate
+    # CSensorGrenadeProjectile::Think_Arm
     [[detonate]]
-        # TODO
-        identifier_windows = 55 8B EC 83 E4 2A 51 53 56 57 8B F1 E8 2A 2A 2A 2A 8B F8
-        identifier_linux = 55 89 E5 57 56 53 8E EC 2A 8B 5D 08 89 1C 24
+        identifier_windows = 56 8B F1 57 8B 86 D4 00 00 00 C1 E8 0C A8 01 74 2A E8 2A 2A 2A 2A F3 0F 10 86 80 01 00 00 F3 0F 10 96 7C 01 00 00 F3 0F 10 8E 84 01 00 00 F3 0F 59 D2 F3 0F 59 C0 F3 0F 59 C9 F3 0F 58 D0 F3 0F 58 D1 F3 0F 10 0D 2A 2A 2A 2A 0F 28 C2 F3 0F 51 C0 0F 2F C1 76 2A 8B 0D 2A 2A 2A 2A F3 0F 10 41 10 F3 0F 58 C1 0F 2E 05 2A 2A 2A 2A 9F F6 C4 44 7A 2A 83 CF FF EB 2A F3 0F 5E 41 20 F3 0F 58 05 2A 2A 2A 2A F3 0F 2C F8 39 BE A4 00 00 00 8D 96 A4 00 00 00 74 2A 8B 82 5C FF FF FF 8D 8A 5C FF FF FF 52 FF 90 D4 00 00 00 89 BE A4 00 00 00 83 FF FF 8B CE 0F 95 C0 0F B6 C0 50 E8 2A 2A 2A 2A 5F 5E C3
+        identifier_linux = 55 89 E5 53 83 EC 34 8B 5D 08 F6 83 2A 00 00 00 10
+
+    # CSensorGrenadeProjectile::SensorThink
+    [[sensor_think]]
+        identifier_windows = 55 8B EC 83 E4 F8 51 53 56 57 8B F1 E8 2A 2A 2A 2A 8B F8
+        identifier_linux = 55 89 E5 57 56 53 83 EC 3C 8B 5D 08 89 1C 24 E8 2A 2A 2A 2A 85 C0
+
+    # CSensorGrenadeProjectile::DoDetectWave
+    [[do_detect_wave]]
+        identifier_windows = 53 8B DC 83 EC 08 83 E4 F0 83 C4 04 55 8B 6B 04 89 6C 24 04 8B EC 81 EC 38 01 00 00 56 8B F1
+        identifier_linux = 55 89 E5 57 56 53 81 EC BC 01 00 00 8B 55 08 89 14 24
+
+
+[instance_attribute]
+
+    [[timer]]
+        offset_windows = 0x570
+        offset_linux = 0x588
+        type = FLOAT

--- a/addons/source-python/data/source-python/entities/csgo/CSmokeGrenadeProjectile.ini
+++ b/addons/source-python/data/source-python/entities/csgo/CSmokeGrenadeProjectile.ini
@@ -3,11 +3,10 @@ srv_check = False
 
 [function]
 
-    # CSmokeGrenadeProjectile::Think_Detonate
+    # CSmokeGrenadeProjectile::SmokeDetonate
     [[detonate]]
-        # TODO
         identifier_windows = 55 8B EC 83 EC 18 56 8B F1 8B 0D 2A 2A 2A 2A 57
-        identifier_linux = 55 89 E5 57 56 53 83 EC 5C 8B 75 08
+        identifier_linux = 55 89 E5 57 56 53 83 EC 5C 8B 75 08 C7 44 24 08 00 00 26 43
 
 
 [property]


### PR DESCRIPTION
Tested on Linux and Windows.

Added functions and timer attribute to the weird CSensorGrenadeProjectile (tagrenade_projectile/weapon_tagrenade).

I added all the functions related to detonate. Which function to use depends on what you want the plugin to do. Normally, with Think_Arm, SensorThink is used for the next Think, and current_time+2.0 is put in the timer, but if you want to make it blow up immediately, you can choose either SensorThink or just DoDetectWave.


Also, you can detect the DetectWave by hooking Player.blind.
```python
#   Entities
from entities.hooks import EntityCondition
from entities.hooks import EntityPreHook
#   Memory
from memory import make_object
#   Player
from players.entity import Player

@EntityPreHook(EntityCondition.is_player, "blind")
def on_blind(args):
    if (args[1] == 0.019999999552965164 and
        args[2] == 1.0 and
        args[3] == 128.0):
        print(make_object(Player, args[0]).name, "DetectWave")
```