### PR TITLE
Fixed an animation error when setting a model to Player.

### DIFF
--- a/addons/source-python/data/source-python/entities/bms/CBaseEntity.ini
+++ b/addons/source-python/data/source-python/entities/bms/CBaseEntity.ini
@@ -1,5 +1,11 @@
 [virtual_function]
 
+    # _ZN11CBaseEntity8SetModelEPKc
+    [[_set_model]]
+        offset_linux = 27
+        offset_windows = 26
+        arguments = STRING
+
     # _ZN11CBaseEntity9SetParentEPS_i
     [[set_parent]]
         offset_linux = 38

--- a/addons/source-python/data/source-python/entities/bms/CBaseEntity.ini
+++ b/addons/source-python/data/source-python/entities/bms/CBaseEntity.ini
@@ -1,7 +1,7 @@
 [virtual_function]
 
     # _ZN11CBaseEntity8SetModelEPKc
-    [[_set_model]]
+    [[set_model]]
         offset_linux = 27
         offset_windows = 26
         arguments = STRING

--- a/addons/source-python/data/source-python/entities/csgo/CBaseEntity.ini
+++ b/addons/source-python/data/source-python/entities/csgo/CBaseEntity.ini
@@ -4,7 +4,7 @@ srv_check = False
 [virtual_function]
 
     # _ZN11CBaseEntity8SetModelEPKc
-    [[_set_model]]
+    [[set_model]]
         offset_linux = 28
         offset_windows = 27
         arguments = STRING

--- a/addons/source-python/data/source-python/entities/csgo/CBaseEntity.ini
+++ b/addons/source-python/data/source-python/entities/csgo/CBaseEntity.ini
@@ -3,6 +3,12 @@ srv_check = False
 
 [virtual_function]
 
+    # _ZN11CBaseEntity8SetModelEPKc
+    [[_set_model]]
+        offset_linux = 28
+        offset_windows = 27
+        arguments = STRING
+
     # _ZN11CBaseEntity9SetParentEPS_i
     [[set_parent]]
         offset_linux = 40

--- a/addons/source-python/data/source-python/entities/gmod/CBaseEntity.ini
+++ b/addons/source-python/data/source-python/entities/gmod/CBaseEntity.ini
@@ -1,5 +1,11 @@
 [virtual_function]
 
+    # _ZN11CBaseEntity8SetModelEPKc
+    [[_set_model]]
+        offset_linux = 25
+        offset_windows = 24
+        arguments = STRING
+
     # _ZN11CBaseEntity9SetParentEPS_i
     [[set_parent]]
         offset_linux = 35

--- a/addons/source-python/data/source-python/entities/gmod/CBaseEntity.ini
+++ b/addons/source-python/data/source-python/entities/gmod/CBaseEntity.ini
@@ -1,7 +1,7 @@
 [virtual_function]
 
     # _ZN11CBaseEntity8SetModelEPKc
-    [[_set_model]]
+    [[set_model]]
         offset_linux = 25
         offset_windows = 24
         arguments = STRING

--- a/addons/source-python/data/source-python/entities/l4d2/CBaseEntity.ini
+++ b/addons/source-python/data/source-python/entities/l4d2/CBaseEntity.ini
@@ -1,5 +1,11 @@
 [virtual_function]
 
+    # _ZN11CBaseEntity8SetModelEPKc
+    [[_set_model]]
+        offset_linux = 28
+        offset_windows = 27
+        arguments = STRING
+
     # _ZN11CBaseEntity9SetParentEPS_i
     [[set_parent]]
         offset_linux = 38

--- a/addons/source-python/data/source-python/entities/l4d2/CBaseEntity.ini
+++ b/addons/source-python/data/source-python/entities/l4d2/CBaseEntity.ini
@@ -1,7 +1,7 @@
 [virtual_function]
 
     # _ZN11CBaseEntity8SetModelEPKc
-    [[_set_model]]
+    [[set_model]]
         offset_linux = 28
         offset_windows = 27
         arguments = STRING

--- a/addons/source-python/data/source-python/entities/orangebox/CBaseEntity.ini
+++ b/addons/source-python/data/source-python/entities/orangebox/CBaseEntity.ini
@@ -1,5 +1,11 @@
 [virtual_function]
 
+    # _ZN11CBaseEntity8SetModelEPKc
+    [[_set_model]]
+        offset_linux = 25
+        offset_windows = 24
+        arguments = STRING
+
     # _ZN11CBaseEntity9SetParentEPS_i
     [[set_parent]]
         offset_linux = 35

--- a/addons/source-python/data/source-python/entities/orangebox/CBaseEntity.ini
+++ b/addons/source-python/data/source-python/entities/orangebox/CBaseEntity.ini
@@ -1,7 +1,7 @@
 [virtual_function]
 
     # _ZN11CBaseEntity8SetModelEPKc
-    [[_set_model]]
+    [[set_model]]
         offset_linux = 25
         offset_windows = 24
         arguments = STRING

--- a/addons/source-python/packages/source-python/entities/_base.py
+++ b/addons/source-python/packages/source-python/entities/_base.py
@@ -425,16 +425,21 @@ class Entity(BaseEntity, Pointer, metaclass=_EntityCaching):
 
         return Model(model_name)
 
+    @wrap_entity_mem_func
     def set_model(self, model):
         """Set the entity's model to the given model.
 
-        :param Model model:
-            The model to set.
+        :param str/Model model:
+            The model path or model to set.
         """
-        self._set_model(model.path)
+        if isinstance(model, Model):
+            model = model.path
+
+        return [model]
 
     model = property(
-        get_model, set_model,
+        get_model,
+        lambda self, model: self.set_model(model),
         doc="""Property to get/set the entity's model.
 
         .. seealso:: :meth:`get_model` and :meth:`set_model`""")

--- a/addons/source-python/packages/source-python/entities/_base.py
+++ b/addons/source-python/packages/source-python/entities/_base.py
@@ -431,8 +431,7 @@ class Entity(BaseEntity, Pointer, metaclass=_EntityCaching):
         :param Model model:
             The model to set.
         """
-        self.model_index = model.index
-        self.model_name = model.path
+        self._set_model(model.path)
 
     model = property(
         get_model, set_model,


### PR DESCRIPTION
I'm not sure if this only applies to CS:GO, but certain models seem to have problems with animation when the model is attached to player by model_index. It might be related to CCSGOPlayerAnimState::Reset(void) or something like that.

If the model is set by entity.model_index, the problem remains, but I can't decide what to do. Is it better to leave it as it is, as entity.model_name can't set the model?

Offsets other than Garry's Mod were borrowed from SourceMod, thanks to AlliedModders/SourceMod.