### PR TITLE
Changed GetEffects/SetEffects to DatamapProperty.

### DIFF
--- a/src/core/modules/entities/entities_entity.cpp
+++ b/src/core/modules/entities/entities_entity.cpp
@@ -779,13 +779,13 @@ void CBaseEntityWrapper::SetDamageFilter(const char* filter)
 int CBaseEntityWrapper::GetEffects()
 {
 	static int offset = FindDatamapPropertyOffset("m_fEffects");
-	return GetDatamapPropertyByOffset<int>(offset);
+	return GetNetworkPropertyByOffset<int>(offset);
 }
 
 void CBaseEntityWrapper::SetEffects(int effects)
 {
 	static int offset = FindDatamapPropertyOffset("m_fEffects");
-	SetDatamapPropertyByOffset<int>(offset, effects);
+	SetNetworkPropertyByOffset<int>(offset, effects);
 }
 
 

--- a/src/core/modules/entities/entities_entity.cpp
+++ b/src/core/modules/entities/entities_entity.cpp
@@ -279,9 +279,11 @@ int CBaseEntityWrapper::FindNetworkPropertyOffset(const char* name)
 
 	int offset;
 	offset = SendTableSharedExt::find_offset(pServerClass->m_pTable, name);
+	if (offset == -1)
+		BOOST_RAISE_EXCEPTION(PyExc_ValueError, "Unable to find property '%s'.", name)
 
 	// TODO: Proxied RecvTables/Arrays
-	if (offset == -1 || offset == 0)
+	if (offset == 0)
 		offset = FindDatamapPropertyOffset(name);
 
 	return offset;
@@ -776,14 +778,14 @@ void CBaseEntityWrapper::SetDamageFilter(const char* filter)
 
 int CBaseEntityWrapper::GetEffects()
 {
-	static int offset = FindNetworkPropertyOffset("m_fEffects");
-	return GetNetworkPropertyByOffset<int>(offset);
+	static int offset = FindDatamapPropertyOffset("m_fEffects");
+	return GetDatamapPropertyByOffset<int>(offset);
 }
 
 void CBaseEntityWrapper::SetEffects(int effects)
 {
-	static int offset = FindNetworkPropertyOffset("m_fEffects");
-	SetNetworkPropertyByOffset<int>(offset, effects);
+	static int offset = FindDatamapPropertyOffset("m_fEffects");
+	SetDatamapPropertyByOffset<int>(offset, effects);
 }
 
 

--- a/src/core/modules/entities/entities_entity.cpp
+++ b/src/core/modules/entities/entities_entity.cpp
@@ -279,11 +279,9 @@ int CBaseEntityWrapper::FindNetworkPropertyOffset(const char* name)
 
 	int offset;
 	offset = SendTableSharedExt::find_offset(pServerClass->m_pTable, name);
-	if (offset == -1)
-		BOOST_RAISE_EXCEPTION(PyExc_ValueError, "Unable to find property '%s'.", name)
 
 	// TODO: Proxied RecvTables/Arrays
-	if (offset == 0)
+	if (offset == -1 || offset == 0)
 		offset = FindDatamapPropertyOffset(name);
 
 	return offset;


### PR DESCRIPTION
I'm not sure why it raises excption when SendTableSharedExt::find_offset returns -1, but I changed it this way because certain entities/properties need to find the offset from the datamap.

Code(CS:GO/Linux):
```python
from entities.entity import Entity

beam = Entity.create("env_beam")
print(beam.effects)
```
Output:
```
[SP] Caught an Exception:
Traceback (most recent call last):
  File "../addons/source-python/packages/source-python/plugins/command.py", line 164, in load_plugin
    plugin = self.manager.load(plugin_name)
  File "../addons/source-python/packages/source-python/plugins/manager.py", line 207, in load
    plugin._load()
  File "../addons/source-python/packages/source-python/plugins/instance.py", line 74, in _load
    self.module = import_module(self.import_name)
  File "../addons/source-python/plugins/test/test.py", line 4, in <module>
    print(beam.effects)

ValueError: Unable to find property 'm_fEffects'.
```
After:
```
0
```