### PR TITLE
Adds entity collisions functionalities.

### DIFF
--- a/addons/source-python/data/source-python/entities/bms/CBaseEntity.ini
+++ b/addons/source-python/data/source-python/entities/bms/CBaseEntity.ini
@@ -51,8 +51,8 @@
 
     # _ZNK11CBasePlayer25PhysicsSolidMaskForEntityEv
     [[get_solid_mask]]
-        offset_linux = 181
-        offset_windows = 180
+        offset_linux = 180
+        offset_windows = 179
         return_type = UINT
 
 

--- a/addons/source-python/data/source-python/entities/bms/CBaseEntity.ini
+++ b/addons/source-python/data/source-python/entities/bms/CBaseEntity.ini
@@ -49,6 +49,12 @@
         offset_windows = 109
         arguments = POINTER
 
+    # _ZNK11CBasePlayer25PhysicsSolidMaskForEntityEv
+    [[get_solid_mask]]
+        offset_linux = 181
+        offset_windows = 180
+        return_type = UINT
+
 
 [input]
 

--- a/addons/source-python/data/source-python/entities/csgo/CBaseEntity.ini
+++ b/addons/source-python/data/source-python/entities/csgo/CBaseEntity.ini
@@ -51,3 +51,10 @@ srv_check = False
         offset_linux = 105
         offset_windows = 104
         arguments = POINTER
+
+    # _ZNK11CBasePlayer25PhysicsSolidMaskForEntityEv
+    # https://gist.github.com/jordanbriere/679e6d09ebaa9830979b6f60e61d4b9c
+    [[get_solid_mask]]
+        offset_linux = 169
+        offset_windows = 168
+        return_type = UINT

--- a/addons/source-python/data/source-python/entities/gmod/CBaseEntity.ini
+++ b/addons/source-python/data/source-python/entities/gmod/CBaseEntity.ini
@@ -48,3 +48,9 @@
         offset_linux = 103
         offset_windows = 102
         arguments = POINTER
+
+    # _ZNK11CBasePlayer25PhysicsSolidMaskForEntityEv
+    [[get_solid_mask]]
+        offset_linux = 173
+        offset_windows = 172
+        return_type = UINT

--- a/addons/source-python/data/source-python/entities/l4d2/CBaseEntity.ini
+++ b/addons/source-python/data/source-python/entities/l4d2/CBaseEntity.ini
@@ -48,3 +48,9 @@
         offset_linux = 110
         offset_windows = 109
         arguments = POINTER
+
+    # _ZNK11CBasePlayer25PhysicsSolidMaskForEntityEv
+    [[get_solid_mask]]
+        offset_linux = 178
+        offset_windows = 177
+        return_type = UINT

--- a/addons/source-python/data/source-python/entities/orangebox/CBaseEntity.ini
+++ b/addons/source-python/data/source-python/entities/orangebox/CBaseEntity.ini
@@ -49,6 +49,12 @@
         offset_windows = 100
         arguments = POINTER
 
+    # _ZNK11CBasePlayer25PhysicsSolidMaskForEntityEv
+    [[get_solid_mask]]
+        offset_linux = 168
+        offset_windows = 167
+        return_type = UINT
+
 
 [input]
 

--- a/addons/source-python/docs/source-python/source/developing/module_tutorials/listeners.rst
+++ b/addons/source-python/docs/source-python/source/developing/module_tutorials/listeners.rst
@@ -329,7 +329,11 @@ OnEntityCollision
 
 Called when a non-player entity is about to collide with another entity.
 
-.. note:: This listener can be extremely noisy. Use :class:`entities.collisions.CollisionHash` if you don't have dynamic conditions to test for.
+.. note::
+
+    This listener can be extremely noisy. Use :class:`entities.collisions.CollisionHash`,
+    :class:`entities.collisions.CollisionMap`, or :class:`entities.collisions.CollisionSet`
+    if you don't have dynamic conditions to test for.
 
 .. code-block:: python
 
@@ -428,7 +432,11 @@ OnPlayerCollision
 
 Called when a player is about to collide with an entity.
 
-.. note:: This listener can be extremely noisy. Use :class:`entities.collisions.CollisionHash` if you don't have dynamic conditions to test for.
+.. note::
+
+    This listener can be extremely noisy. Use :class:`entities.collisions.CollisionHash`,
+    :class:`entities.collisions.CollisionMap`, or :class:`entities.collisions.CollisionSet`
+    if you don't have dynamic conditions to test for.
 
 .. code-block:: python
 

--- a/addons/source-python/docs/source-python/source/developing/module_tutorials/listeners.rst
+++ b/addons/source-python/docs/source-python/source/developing/module_tutorials/listeners.rst
@@ -327,7 +327,7 @@ Called when a networked entity has been spawned.
 OnEntityCollision
 -----------------
 
-Called when an entity is about to collide with another.
+Called when a non-player entity is about to collide with another entity.
 
 .. note:: This listener can be extremely noisy. Use :class:`entities.collisions.CollisionHash` if you don't have dynamic conditions to test for.
 
@@ -337,8 +337,8 @@ Called when an entity is about to collide with another.
 
     @OnEntityCollision
     def on_entity_collision(entity, other):
-        # Disable teammates collisions
-        return entity.team_index != other.team_index
+        # Disable weapons/projectiles collisions with everything except players
+        return not (entity.is_weapon() and not other.is_player())
 
 
 OnLevelInit
@@ -421,6 +421,25 @@ Called when the button state of a player changed.
 
     Use :func:`listeners.get_button_combination_status` to check if a specific
     button or button combination has been pressed or released.
+
+
+OnPlayerCollision
+-----------------
+
+Called when a player is about to collide with an entity.
+
+.. note:: This listener can be extremely noisy. Use :class:`entities.collisions.CollisionHash` if you don't have dynamic conditions to test for.
+
+.. code-block:: python
+
+    from listeners import OnPlayerCollision
+
+    @OnPlayerCollision
+    def on_player_collision(player, entity):
+        # Disable teammates collisions
+        if not entity.is_player():
+            return
+        return player.team_index != entity.team_index
 
 
 OnPlayerRunCommand

--- a/addons/source-python/docs/source-python/source/developing/module_tutorials/listeners.rst
+++ b/addons/source-python/docs/source-python/source/developing/module_tutorials/listeners.rst
@@ -324,6 +324,23 @@ Called when a networked entity has been spawned.
         pass
 
 
+OnEntityCollision
+-----------------
+
+Called when an entity is about to collide with another.
+
+.. note:: This listener can be extremely noisy. Use :class:`entities.collisions.CollisionHash` if you don't have dynamic conditions to test for.
+
+.. code-block:: python
+
+    from listeners import OnEntityCollision
+
+    @OnEntityCollision
+    def on_entity_collision(entity, other):
+        # Disable teammates collisions
+        return entity.team_index != other.team_index
+
+
 OnLevelInit
 -----------
 

--- a/addons/source-python/packages/source-python/entities/collisions.py
+++ b/addons/source-python/packages/source-python/entities/collisions.py
@@ -3,6 +3,14 @@
 """Provides entity collisions functionality."""
 
 # =============================================================================
+# >> IMPORTS
+# =============================================================================
+# Source.Python Imports
+#   Core
+from core import AutoUnload
+
+
+# =============================================================================
 # >> FORWARD IMPORTS
 # =============================================================================
 # Source.Python Imports
@@ -16,3 +24,10 @@ from _entities._collisions import CollisionHash
 __all__ = [
     'CollisionHash',
 ]
+
+
+# =============================================================================
+# >> INITIALIZATION
+# =============================================================================
+# Inject AutoUnload into CollisionHash's hierarchy.
+CollisionHash.__bases__ = (AutoUnload,) + CollisionHash.__bases__

--- a/addons/source-python/packages/source-python/entities/collisions.py
+++ b/addons/source-python/packages/source-python/entities/collisions.py
@@ -15,6 +15,7 @@ from core import AutoUnload
 # =============================================================================
 # Source.Python Imports
 #   Entities
+from _entities._collisions import BaseCollisionHash
 from _entities._collisions import CollisionHash
 
 
@@ -22,6 +23,7 @@ from _entities._collisions import CollisionHash
 # >> ALL DECLARATION
 # =============================================================================
 __all__ = [
+    'BaseCollisionHash',
     'CollisionHash',
 ]
 
@@ -29,5 +31,5 @@ __all__ = [
 # =============================================================================
 # >> INITIALIZATION
 # =============================================================================
-# Inject AutoUnload into CollisionHash's hierarchy.
-CollisionHash.__bases__ = (AutoUnload,) + CollisionHash.__bases__
+# Inject AutoUnload into BaseCollisionHash's hierarchy.
+BaseCollisionHash.__bases__ = (AutoUnload,) + BaseCollisionHash.__bases__

--- a/addons/source-python/packages/source-python/entities/collisions.py
+++ b/addons/source-python/packages/source-python/entities/collisions.py
@@ -19,6 +19,7 @@ from core import WeakAutoUnload
 from _entities._collisions import CollisionHash
 from _entities._collisions import CollisionManager
 from _entities._collisions import CollisionRules
+from _entities._collisions import CollisionSet
 from _entities._collisions import collision_manager
 
 
@@ -30,6 +31,7 @@ __all__ = [
     'CollisionHook',
     'CollisionManager',
     'CollisionRules',
+    'CollisionSet',
     'collision_manager',
 ]
 

--- a/addons/source-python/packages/source-python/entities/collisions.py
+++ b/addons/source-python/packages/source-python/entities/collisions.py
@@ -17,6 +17,8 @@ from core import AutoUnload
 #   Entities
 from _entities._collisions import BaseCollisionHash
 from _entities._collisions import CollisionHash
+from _entities._collisions import CollisionManager
+from _entities._collisions import collision_manager
 
 
 # =============================================================================
@@ -25,6 +27,9 @@ from _entities._collisions import CollisionHash
 __all__ = [
     'BaseCollisionHash',
     'CollisionHash',
+    'CollisionHook',
+    'CollisionManager',
+    'collision_manager',
 ]
 
 
@@ -33,3 +38,19 @@ __all__ = [
 # =============================================================================
 # Inject AutoUnload into BaseCollisionHash's hierarchy.
 BaseCollisionHash.__bases__ = (AutoUnload,) + BaseCollisionHash.__bases__
+
+
+# =============================================================================
+# >> CLASSES
+# =============================================================================
+class CollisionHook(AutoUnload):
+    """Decorator used to create collision hooks that auto unload."""
+
+    def __init__(self, callback):
+        """Registers the collision hook."""
+        self.callback = callback
+        collision_manager.register_hook(callback)
+
+    def _unload_instance(self):
+        """Unregisters the collision hook."""
+        collision_manager.unregister_hook(self.callback)

--- a/addons/source-python/packages/source-python/entities/collisions.py
+++ b/addons/source-python/packages/source-python/entities/collisions.py
@@ -29,7 +29,6 @@ from _entities._collisions import collision_manager
 # >> ALL DECLARATION
 # =============================================================================
 __all__ = [
-    'SOLID_MASKS',
     'BaseCollisionHash',
     'CollisionHash',
     'CollisionHook',
@@ -44,30 +43,6 @@ __all__ = [
 # Inject AutoUnload into BaseCollisionHash's hierarchy.
 if not issubclass(BaseCollisionHash, AutoUnload):
     BaseCollisionHash.__bases__ = (AutoUnload,) + BaseCollisionHash.__bases__
-
-
-# =============================================================================
-# >> GLOBAL VARIABLES
-# =============================================================================
-#: Masks that are considered solid.
-SOLID_MASKS = (
-    ContentMasks.SOLID,
-    ContentMasks.PLAYER_SOLID,
-    ContentMasks.NPC_SOLID,
-
-    # Teams
-    ContentMasks.PLAYER_SOLID | ContentFlags.TEAM1,
-    ContentMasks.PLAYER_SOLID | ContentFlags.TEAM2,
-)
-
-# Assign masks that are considered solid for the current game.
-if GAME_NAME == 'csgo':
-    SOLID_MASKS += (
-        # Projectiles
-        (ContentFlags.CURRENT_90 | ContentMasks.SOLID |
-            ContentMasks.VISIBLE_AND_NPCS | ContentFlags.HITBOX
-        ) & ~ContentFlags.DEBRIS,
-    )
 
 
 # =============================================================================

--- a/addons/source-python/packages/source-python/entities/collisions.py
+++ b/addons/source-python/packages/source-python/entities/collisions.py
@@ -19,6 +19,7 @@ from core import WeakAutoUnload
 from _entities._collisions import CollisionHash
 from _entities._collisions import CollisionManager
 from _entities._collisions import CollisionMap
+from _entities._collisions import CollisionMode
 from _entities._collisions import CollisionRules
 from _entities._collisions import CollisionSet
 from _entities._collisions import collision_manager
@@ -32,6 +33,7 @@ __all__ = [
     'CollisionHook',
     'CollisionManager',
     'CollisionMap',
+    'CollisionMode',
     'CollisionRules',
     'CollisionSet',
     'collision_manager',

--- a/addons/source-python/packages/source-python/entities/collisions.py
+++ b/addons/source-python/packages/source-python/entities/collisions.py
@@ -1,0 +1,18 @@
+# ../entities/collisions.py
+
+"""Provides entity collisions functionality."""
+
+# =============================================================================
+# >> FORWARD IMPORTS
+# =============================================================================
+# Source.Python Imports
+#   Entities
+from _entities._collisions import CollisionHash
+
+
+# =============================================================================
+# >> ALL DECLARATION
+# =============================================================================
+__all__ = [
+    'CollisionHash',
+]

--- a/addons/source-python/packages/source-python/entities/collisions.py
+++ b/addons/source-python/packages/source-python/entities/collisions.py
@@ -7,7 +7,11 @@
 # =============================================================================
 # Source.Python Imports
 #   Core
+from core import GAME_NAME
 from core import AutoUnload
+#   Engines
+from engines.trace import ContentFlags
+from engines.trace import ContentMasks
 
 
 # =============================================================================
@@ -25,6 +29,7 @@ from _entities._collisions import collision_manager
 # >> ALL DECLARATION
 # =============================================================================
 __all__ = [
+    'SOLID_MASKS',
     'BaseCollisionHash',
     'CollisionHash',
     'CollisionHook',
@@ -37,7 +42,32 @@ __all__ = [
 # >> INITIALIZATION
 # =============================================================================
 # Inject AutoUnload into BaseCollisionHash's hierarchy.
-BaseCollisionHash.__bases__ = (AutoUnload,) + BaseCollisionHash.__bases__
+if not issubclass(BaseCollisionHash, AutoUnload):
+    BaseCollisionHash.__bases__ = (AutoUnload,) + BaseCollisionHash.__bases__
+
+
+# =============================================================================
+# >> GLOBAL VARIABLES
+# =============================================================================
+#: Masks that are considered solid.
+SOLID_MASKS = (
+    ContentMasks.SOLID,
+    ContentMasks.PLAYER_SOLID,
+    ContentMasks.NPC_SOLID,
+
+    # Teams
+    ContentMasks.PLAYER_SOLID | ContentFlags.TEAM1,
+    ContentMasks.PLAYER_SOLID | ContentFlags.TEAM2,
+)
+
+# Assign masks that are considered solid for the current game.
+if GAME_NAME == 'csgo':
+    SOLID_MASKS += (
+        # Projectiles
+        (ContentFlags.CURRENT_90 | ContentMasks.SOLID |
+            ContentMasks.VISIBLE_AND_NPCS | ContentFlags.HITBOX
+        ) & ~ContentFlags.DEBRIS,
+    )
 
 
 # =============================================================================

--- a/addons/source-python/packages/source-python/entities/collisions.py
+++ b/addons/source-python/packages/source-python/entities/collisions.py
@@ -18,6 +18,7 @@ from core import WeakAutoUnload
 #   Entities
 from _entities._collisions import CollisionHash
 from _entities._collisions import CollisionManager
+from _entities._collisions import CollisionMap
 from _entities._collisions import CollisionRules
 from _entities._collisions import CollisionSet
 from _entities._collisions import collision_manager
@@ -30,6 +31,7 @@ __all__ = [
     'CollisionHash',
     'CollisionHook',
     'CollisionManager',
+    'CollisionMap',
     'CollisionRules',
     'CollisionSet',
     'collision_manager',

--- a/addons/source-python/packages/source-python/entities/collisions.py
+++ b/addons/source-python/packages/source-python/entities/collisions.py
@@ -7,11 +7,8 @@
 # =============================================================================
 # Source.Python Imports
 #   Core
-from core import GAME_NAME
 from core import AutoUnload
-#   Engines
-from engines.trace import ContentFlags
-from engines.trace import ContentMasks
+from core import WeakAutoUnload
 
 
 # =============================================================================
@@ -19,9 +16,9 @@ from engines.trace import ContentMasks
 # =============================================================================
 # Source.Python Imports
 #   Entities
-from _entities._collisions import BaseCollisionHash
 from _entities._collisions import CollisionHash
 from _entities._collisions import CollisionManager
+from _entities._collisions import CollisionRules
 from _entities._collisions import collision_manager
 
 
@@ -29,10 +26,10 @@ from _entities._collisions import collision_manager
 # >> ALL DECLARATION
 # =============================================================================
 __all__ = [
-    'BaseCollisionHash',
     'CollisionHash',
     'CollisionHook',
     'CollisionManager',
+    'CollisionRules',
     'collision_manager',
 ]
 
@@ -40,9 +37,9 @@ __all__ = [
 # =============================================================================
 # >> INITIALIZATION
 # =============================================================================
-# Inject AutoUnload into BaseCollisionHash's hierarchy.
-if not issubclass(BaseCollisionHash, AutoUnload):
-    BaseCollisionHash.__bases__ = (AutoUnload,) + BaseCollisionHash.__bases__
+# Inject WeakAutoUnload into CollisionRules's hierarchy.
+if not issubclass(CollisionRules, WeakAutoUnload):
+    CollisionRules.__bases__ = (WeakAutoUnload,) + CollisionRules.__bases__
 
 
 # =============================================================================

--- a/addons/source-python/packages/source-python/listeners/__init__.py
+++ b/addons/source-python/packages/source-python/listeners/__init__.py
@@ -73,6 +73,7 @@ from _listeners import on_query_cvar_value_finished_listener_manager
 from _listeners import on_server_activate_listener_manager
 from _listeners import on_tick_listener_manager
 from _listeners import on_server_output_listener_manager
+from _listeners import on_player_collision_listener_manager
 from _listeners import on_player_run_command_listener_manager
 from _listeners import on_button_state_changed_listener_manager
 
@@ -111,6 +112,7 @@ __all__ = ('ButtonStatus',
            'OnLevelEnd',
            'OnNetworkidValidated',
            'OnButtonStateChanged',
+           'OnPlayerCollision',
            'OnPlayerRunCommand',
            'OnPluginLoaded',
            'OnPluginLoading',
@@ -157,6 +159,7 @@ __all__ = ('ButtonStatus',
            'on_tick_listener_manager',
            'on_version_update_listener_manager',
            'on_server_output_listener_manager',
+           'on_player_collision_listener_manager',
            'on_player_run_command_listener_manager',
            'on_button_state_changed_listener_manager',
            )
@@ -496,6 +499,12 @@ class OnLevelEnd(ListenerManagerDecorator):
 
     # Guard variable to ensure this listener gets called only once per map.
     _level_initialized = False
+
+
+class OnPlayerCollision(ListenerManagerDecorator):
+    """Register/unregister a OnPlayerCollision listener."""
+
+    manager = on_player_collision_listener_manager
 
 
 class OnPlayerRunCommand(ListenerManagerDecorator):

--- a/addons/source-python/packages/source-python/listeners/__init__.py
+++ b/addons/source-python/packages/source-python/listeners/__init__.py
@@ -65,6 +65,7 @@ from _listeners import on_entity_spawned_listener_manager
 from _listeners import on_networked_entity_spawned_listener_manager
 from _listeners import on_entity_deleted_listener_manager
 from _listeners import on_networked_entity_deleted_listener_manager
+from _listeners import on_entity_collision_listener_manager
 from _listeners import on_data_loaded_listener_manager
 from _listeners import on_combiner_pre_cache_listener_manager
 from _listeners import on_data_unloaded_listener_manager
@@ -98,6 +99,7 @@ __all__ = ('ButtonStatus',
            'OnNetworkedEntityCreated',
            'OnEntityDeleted',
            'OnNetworkedEntityDeleted',
+           'OnEntityCollision',
            'OnEntityOutput',
            'OnEntityOutputListenerManager',
            'OnEntityPreSpawned',
@@ -136,6 +138,7 @@ __all__ = ('ButtonStatus',
            'on_networked_entity_created_listener_manager',
            'on_entity_deleted_listener_manager',
            'on_networked_entity_deleted_listener_manager',
+           'on_entity_collision_listener_manager',
            'on_entity_output_listener_manager',
            'on_entity_pre_spawned_listener_manager',
            'on_networked_entity_pre_spawned_listener_manager',
@@ -406,6 +409,12 @@ class OnNetworkedEntityDeleted(ListenerManagerDecorator):
     """Register/unregister a OnNetworkedEntityDeleted listener."""
 
     manager = on_networked_entity_deleted_listener_manager
+
+
+class OnEntityCollision(ListenerManagerDecorator):
+    """Register/unregister a OnEntityCollision listener."""
+
+    manager = on_entity_collision_listener_manager
 
 
 class OnDataLoaded(ListenerManagerDecorator):

--- a/addons/source-python/packages/source-python/plugins/manager.py
+++ b/addons/source-python/packages/source-python/plugins/manager.py
@@ -11,6 +11,8 @@ from collections import OrderedDict
 #   Configobj
 from configobj import ConfigObj
 from configobj import Section
+#   GC
+from gc import collect
 #   Importlib
 from importlib.util import find_spec
 from importlib.util import spec_from_file_location
@@ -234,6 +236,7 @@ class PluginManager(OrderedDict):
 
         self._remove_modules(plugin_name)
         del self[plugin_name]
+        collect()
         on_plugin_unloaded_manager.notify(plugin)
 
     def reload(self, plugin_name):

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -243,6 +243,7 @@ Set(SOURCEPYTHON_ENTITIES_MODULE_SOURCES
     core/modules/entities/entities_entity.cpp
     core/modules/entities/entities_entity_wrap.cpp
     core/modules/entities/entities_collisions.cpp
+    core/modules/entities/entities_collisions_wrap.cpp
 )
 
 # ------------------------------------------------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -225,6 +225,7 @@ Set(SOURCEPYTHON_ENTITIES_MODULE_HEADERS
     core/modules/entities/${SOURCE_ENGINE}/entities_props_wrap.h
     core/modules/entities/${SOURCE_ENGINE}/entities_constants_wrap.h
     core/modules/entities/entities_entity.h
+    core/modules/entities/entities_collisions.h
 )
 
 Set(SOURCEPYTHON_ENTITIES_MODULE_SOURCES
@@ -241,6 +242,7 @@ Set(SOURCEPYTHON_ENTITIES_MODULE_SOURCES
     core/modules/entities/entities_props_wrap.cpp
     core/modules/entities/entities_entity.cpp
     core/modules/entities/entities_entity_wrap.cpp
+    core/modules/entities/entities_collisions.cpp
 )
 
 # ------------------------------------------------------------------

--- a/src/core/modules/entities/entities_collisions.cpp
+++ b/src/core/modules/entities/entities_collisions.cpp
@@ -259,7 +259,7 @@ bool CCollisionManager::EnterScope(HookType_t eHookType, CHook *pHook)
 	}
 
 	scope.m_pFilter = pWrapper;
-	scope.m_uiIndex = pHandle.GetEntryIndex();
+	scope.m_uiIndex = uiIndex;
 	scope.m_pExtraShouldHitCheckFunction = pWrapper->m_pExtraShouldHitCheckFunction;
 	scope.m_pFilter->m_pExtraShouldHitCheckFunction = (ShouldHitFunc_t)CCollisionManager::ShouldHitEntity;
 

--- a/src/core/modules/entities/entities_collisions.cpp
+++ b/src/core/modules/entities/entities_collisions.cpp
@@ -230,7 +230,7 @@ bool CCollisionManager::EnterScope(HookType_t eHookType, CHook *pHook)
 	int nMask = pHook->GetArgument<int>(hookData.m_uiMaskIndex);
 
 #if defined(ENGINE_CSGO)
-	if (nMask & CONTENTS_EMPTY ||
+	if ((nMask & CONTENTS_EMPTY ||
 		nMask & CONTENTS_AUX ||
 		nMask & CONTENTS_SLIME ||
 		nMask & CONTENTS_WATER ||
@@ -238,11 +238,11 @@ bool CCollisionManager::EnterScope(HookType_t eHookType, CHook *pHook)
 		nMask & CONTENTS_OPAQUE ||
 		nMask & CONTENTS_IGNORE_NODRAW_OPAQUE ||
 		nMask & CONTENTS_CURRENT_0 || // CONTENTS_BRUSH_PAINT
-		nMask & CONTENTS_CURRENT_90 || // CONTENTS_GRENADECLIP
 		nMask & CONTENTS_DEBRIS ||
 		nMask & CONTENTS_DETAIL ||
 		nMask & CONTENTS_TRANSLUCENT ||
-		nMask & CONTENTS_HITBOX
+		nMask & CONTENTS_HITBOX) &&
+		!(nMask & CONTENTS_CURRENT_90) // CONTENTS_GRENADECLIP
 	) {
 #else
 	if (nMask != MASK_SOLID &&

--- a/src/core/modules/entities/entities_collisions.cpp
+++ b/src/core/modules/entities/entities_collisions.cpp
@@ -100,7 +100,7 @@ void CCollisionManager::Finalize()
 	m_bInitialized = false;
 }
 
-void CCollisionManager::RegisterHash(CCollisionHash *pHash)
+void CCollisionManager::RegisterHash(ICollisionHash *pHash)
 {
 	if (m_vecHashes.HasElement(pHash)) {
 		BOOST_RAISE_EXCEPTION(
@@ -113,7 +113,7 @@ void CCollisionManager::RegisterHash(CCollisionHash *pHash)
 	m_vecHashes.AddToTail(pHash);
 }
 
-void CCollisionManager::UnregisterHash(CCollisionHash *pHash)
+void CCollisionManager::UnregisterHash(ICollisionHash *pHash)
 {
 	if (!m_vecHashes.FindAndRemove(pHash)) {
 		return;
@@ -389,6 +389,27 @@ bool CCollisionManager::ShouldHitEntity(IHandleEntity *pHandleEntity, int conten
 
 
 //-----------------------------------------------------------------------------
+// ICollisionHash class.
+//-----------------------------------------------------------------------------
+ICollisionHash::ICollisionHash()
+{
+	static CCollisionManager *pManager = GetCollisionManager();
+	pManager->RegisterHash(this);
+}
+
+ICollisionHash::~ICollisionHash()
+{
+	UnloadInstance();
+}
+
+void ICollisionHash::UnloadInstance()
+{
+	static CCollisionManager *pManager = GetCollisionManager();
+	pManager->UnregisterHash(this);
+}
+
+
+//-----------------------------------------------------------------------------
 // CCollisionHash class.
 //-----------------------------------------------------------------------------
 CCollisionHash::CCollisionHash()
@@ -401,9 +422,6 @@ CCollisionHash::CCollisionHash()
 			"Failed to create a collision hash."
 		)
 	}
-
-	static CCollisionManager *pManager = GetCollisionManager();
-	pManager->RegisterHash(this);
 }
 
 CCollisionHash::~CCollisionHash()
@@ -412,8 +430,6 @@ CCollisionHash::~CCollisionHash()
 		return;
 	}
 
-	static CCollisionManager *pManager = GetCollisionManager();
-	pManager->UnregisterHash(this);
 	physics->DestroyObjectPairHash(m_pHash);
 }
 
@@ -469,12 +485,6 @@ list CCollisionHash::GetPairs(void *pObject)
 	}
 
 	return oObjects;
-}
-
-void CCollisionHash::UnloadInstance()
-{
-	static CCollisionManager *pManager = GetCollisionManager();
-	pManager->UnregisterHash(this);
 }
 
 

--- a/src/core/modules/entities/entities_collisions.cpp
+++ b/src/core/modules/entities/entities_collisions.cpp
@@ -30,10 +30,425 @@
 // Source.Python
 #include "modules/entities/entities_collisions.h"
 
+#ifdef __linux__
+	#include "modules/memory/memory_rtti.h"
+#endif
+
 
 //-----------------------------------------------------------------------------
-// CEntityCollisionListenerManager's singleton accessor.
+// Externals.
 //-----------------------------------------------------------------------------
+extern IEngineTrace *enginetrace;
+extern IPhysics *physics;
+
+
+//-----------------------------------------------------------------------------
+// CCollisionManager class.
+//-----------------------------------------------------------------------------
+CCollisionManager::CCollisionManager():
+	m_bInitialized(false),
+	m_uiRefCount(0)
+{
+
+}
+
+void CCollisionManager::IncRef()
+{
+	if (!m_uiRefCount) {
+		Initialize();
+	}
+
+	++m_uiRefCount;
+}
+
+void CCollisionManager::DecRef()
+{
+	if (m_uiRefCount <= 0) {
+		return;
+	}
+
+	--m_uiRefCount;
+
+	if (!m_uiRefCount) {
+		Finalize();
+	}
+}
+
+void CCollisionManager::Initialize()
+{
+	if (m_bInitialized) {
+		return;
+	}
+
+	RegisterHook(&IEngineTrace::TraceRay, 3, "TraceRay");
+	RegisterHook(&IEngineTrace::TraceRayAgainstLeafAndEntityList, 4, "TraceRayAgainstLeafAndEntityList");
+	RegisterHook(&IEngineTrace::SweepCollideable, 6, "SweepCollideable");
+
+	m_bInitialized = true;
+}
+
+void CCollisionManager::Finalize()
+{
+	if (!m_bInitialized) {
+		return;
+	}
+
+	UnregisterHook(&IEngineTrace::TraceRay, "TraceRay");
+	UnregisterHook(&IEngineTrace::TraceRayAgainstLeafAndEntityList, "TraceRayAgainstLeafAndEntityList");
+	UnregisterHook(&IEngineTrace::SweepCollideable, "SweepCollideable");
+
+	m_bInitialized = false;
+}
+
+void CCollisionManager::RegisterHash(CCollisionHash *pHash)
+{
+	if (m_vecHashes.HasElement(pHash)) {
+		BOOST_RAISE_EXCEPTION(
+			PyExc_ValueError,
+			"The given hash is already registered."
+		);
+	}
+
+	IncRef();
+	m_vecHashes.AddToTail(pHash);
+}
+
+void CCollisionManager::UnregisterHash(CCollisionHash *pHash)
+{
+	m_vecHashes.FindAndRemove(pHash);
+	DecRef();
+}
+
+template<typename T>
+CHook *CCollisionManager::GetHook(T tFunc, const char *szDebugName)
+{
+	CFunctionInfo *pInfo = GetFunctionInfo(tFunc);
+	if (!pInfo) {
+		BOOST_RAISE_EXCEPTION(
+			PyExc_ValueError,
+			"Failed to retrieve IEngineTrace::%s's info.",
+			szDebugName
+		)
+	}
+
+	CFunction *pFunc = CPointer((unsigned long)((void *)enginetrace)).MakeVirtualFunction(*pInfo);
+	delete pInfo;
+
+	if (!pFunc || !pFunc->IsHookable()) {
+		BOOST_RAISE_EXCEPTION(
+			PyExc_ValueError,
+			"IEngineTrace::%s's function is invalid or not hookable.",
+			szDebugName
+		)
+	}
+
+	void *pAddr = (void *)pFunc->m_ulAddr;
+	CHook *pHook = GetHookManager()->FindHook(pAddr);
+	if (!pHook) {
+		pHook = GetHookManager()->HookFunction(pAddr, pFunc->m_pCallingConvention);
+		if (!pHook) {
+			BOOST_RAISE_EXCEPTION(
+				PyExc_ValueError,
+				"Failed to hook IEngineTrace::%s.",
+				szDebugName
+			)
+		}
+	}
+
+	delete pFunc;
+	return pHook;
+}
+
+template<typename T>
+void CCollisionManager::RegisterHook(T tFunc, unsigned int uiFilterIndex, const char *szDebugName)
+{
+	CHook *pHook = GetHook(tFunc, szDebugName);
+	CollisionHooksMap_t::const_iterator it = m_mapHooks.find(pHook);
+	if (it != m_mapHooks.end()) {
+		BOOST_RAISE_EXCEPTION(
+			PyExc_RuntimeError,
+			"Collision hook \"%s\" is already registered.",
+			szDebugName
+		)
+	}
+
+	m_mapHooks[pHook] = uiFilterIndex;
+
+	pHook->AddCallback(
+		HOOKTYPE_PRE,
+		(HookHandlerFn *)&CCollisionManager::EnterScope
+	);
+
+	pHook->AddCallback(
+		HOOKTYPE_POST,
+		(HookHandlerFn *)&CCollisionManager::ExitScope
+	);
+}
+
+template<typename T>
+void CCollisionManager::UnregisterHook(T tFunc, const char *szDebugName)
+{
+	CHook *pHook = GetHook(tFunc, szDebugName);
+	CollisionHooksMap_t::const_iterator it = m_mapHooks.find(pHook);
+	if (it == m_mapHooks.end()) {
+		BOOST_RAISE_EXCEPTION(
+			PyExc_RuntimeError,
+			"Collision hook \"%s\" is not registered.",
+			szDebugName
+		)
+	}
+
+	pHook->RemoveCallback(
+		HOOKTYPE_PRE,
+		(HookHandlerFn *)&CCollisionManager::EnterScope
+	);
+
+	pHook->RemoveCallback(
+		HOOKTYPE_POST,
+		(HookHandlerFn *)&CCollisionManager::ExitScope
+	);
+
+	m_mapHooks.erase(it);
+}
+
+bool CCollisionManager::EnterScope(HookType_t eHookType, CHook *pHook)
+{
+	static CCollisionManager *pManager = GetCollisionManager();
+
+	CollisionScope_t scope;
+	scope.m_bSkip = true;
+
+	CTraceFilterSimpleWrapper *pWrapper = NULL;
+	ITraceFilter *pFilter = pHook->GetArgument<ITraceFilter *>(pManager->m_mapHooks[pHook]);
+
+#ifdef _WIN32
+	pWrapper = (CTraceFilterSimpleWrapper *)dynamic_cast<CTraceFilterSimple *>(pFilter);
+#elif __linux__
+	static boost::unordered_map<void *, bool> s_mapTables;
+	void *pTable = *(void **)pFilter;
+	boost::unordered_map<void *, bool>::const_iterator it = s_mapTables.find(pTable);
+	if (it == s_mapTables.end()) {
+		s_mapTables[pTable] = GetType(pFilter)->IsDerivedFrom("CTraceFilterSimple");
+	}
+
+	if (s_mapTables[pTable]) {
+		pWrapper = reinterpret_cast<CTraceFilterSimpleWrapper *>(pFilter);
+	}
+#endif
+
+	if (!pWrapper) {
+		pManager->m_vecScopes.push_back(scope);
+		return false;
+	}
+
+	if (!pWrapper->m_pPassEnt) {
+		pManager->m_vecScopes.push_back(scope);
+		return false;
+	}
+
+	const CBaseHandle &pHandle = pWrapper->m_pPassEnt->GetRefEHandle();
+	if (!pHandle.IsValid()) {
+		pManager->m_vecScopes.push_back(scope);
+		return false;
+	}
+
+	unsigned int uiIndex = pHandle.GetEntryIndex();
+	if (uiIndex >= MAX_EDICTS) {
+		pManager->m_vecScopes.push_back(scope);
+		return false;
+	}
+
+	scope.m_pFilter = pWrapper;
+	scope.m_uiIndex = pHandle.GetEntryIndex();
+	scope.m_pExtraShouldHitCheckFunction = pWrapper->m_pExtraShouldHitCheckFunction;
+	scope.m_pFilter->m_pExtraShouldHitCheckFunction = (ShouldHitFunc_t)CCollisionManager::ShouldHitEntity;
+
+	scope.m_bSkip = false;
+	pManager->m_vecScopes.push_back(scope);
+
+	return false;
+}
+
+bool CCollisionManager::ExitScope(HookType_t eHookType, CHook *pHook)
+{
+	static CCollisionManager *pManager = GetCollisionManager();
+	if (pManager->m_vecScopes.empty()) {
+		return false;
+	}
+
+	CollisionScope_t scope = pManager->m_vecScopes.back();
+	pManager->m_vecScopes.pop_back();
+
+	if (!scope.m_bSkip && scope.m_pExtraShouldHitCheckFunction) {
+		scope.m_pFilter->m_pExtraShouldHitCheckFunction = scope.m_pExtraShouldHitCheckFunction;
+		scope.m_pExtraShouldHitCheckFunction = NULL;
+	}
+
+	return false;
+}
+
+bool CCollisionManager::ShouldHitEntity(IHandleEntity *pHandleEntity, int contentsMask)
+{
+	static CCollisionManager *pManager = GetCollisionManager();
+	if (pManager->m_vecScopes.empty()) {
+		return true;
+	}
+
+	CollisionScope_t scope = pManager->m_vecScopes.back();
+	if (scope.m_bSkip) {
+		return true;
+	}
+
+	if (!pHandleEntity) {
+		return true;
+	}
+
+	const CBaseHandle &pHandle = pHandleEntity->GetRefEHandle();
+	if (!pHandle.IsValid()) {
+		return true;
+	}
+
+	unsigned int uiIndex = pHandle.GetEntryIndex();
+	if (uiIndex >= MAX_EDICTS) {
+		return true;
+	}
+
+	if (scope.m_pExtraShouldHitCheckFunction) {
+		if (scope.m_pExtraShouldHitCheckFunction != scope.m_pFilter->m_pExtraShouldHitCheckFunction) {
+			if (!(scope.m_pExtraShouldHitCheckFunction(pHandleEntity, contentsMask))) {
+				return false;
+			}
+		}
+	}
+
+	FOR_EACH_VEC(pManager->m_vecHashes, i) {
+		if (pManager->m_vecHashes[i]->IsPairInHash((void *)scope.m_pFilter->m_pPassEnt, (void *)pHandleEntity)) {
+			return false;
+		}
+	}
+
+	static CEntityCollisionListenerManager *pListener = GetOnEntityCollisionListenerManager();
+	static object Entity = import("entities").attr("entity").attr("Entity");
+
+	object oEntity = Entity(scope.m_uiIndex);
+	object oOther = Entity(uiIndex);
+
+	FOR_EACH_VEC(pListener->m_vecCallables, i) {
+		BEGIN_BOOST_PY()
+			object oResult = pListener->m_vecCallables[i](oEntity, oOther);
+			if (!oResult.is_none() && !extract<bool>(oResult)) {
+				return false;
+			}
+		END_BOOST_PY_NORET()
+	}
+
+	return true;
+}
+
+
+//-----------------------------------------------------------------------------
+// CCollisionHash class.
+//-----------------------------------------------------------------------------
+CCollisionHash::CCollisionHash()
+{
+	m_pHash = physics->CreateObjectPairHash();
+
+	if (!m_pHash) {
+		BOOST_RAISE_EXCEPTION(
+			PyExc_RuntimeError,
+			"Failed to create a collision hash."
+		)
+	}
+
+	GetCollisionManager()->RegisterHash(this);
+}
+
+CCollisionHash::~CCollisionHash()
+{
+	GetCollisionManager()->UnregisterHash(this);
+	physics->DestroyObjectPairHash(m_pHash);
+}
+
+void CCollisionHash::AddPair(void *pObject, void *pOther)
+{
+	m_pHash->AddObjectPair(pObject, pOther);
+}
+
+void CCollisionHash::RemovePair(void *pObject, void *pOther)
+{
+	m_pHash->RemoveObjectPair(pObject, pOther);
+}
+
+void CCollisionHash::RemovePairs(void *pObject)
+{
+	m_pHash->RemoveAllPairsForObject(pObject);
+}
+
+bool CCollisionHash::IsInHash(void *pObject)
+{
+	return m_pHash->IsObjectInHash(pObject);
+}
+
+bool CCollisionHash::IsPairInHash(void *pObject, void *pOther)
+{
+	return m_pHash->IsObjectPairInHash(pObject, pOther);
+}
+
+list CCollisionHash::GetPairs(void *pObject)
+{
+	list oObjects;
+	int nCount = m_pHash->GetPairCountForObject(pObject);
+
+	if (!nCount) {
+		return oObjects;
+	}
+
+	void **ppObjects = (void **)stackalloc(nCount * sizeof(void *));
+	m_pHash->GetPairListForObject(pObject, nCount, ppObjects);
+
+	for (int i = 0; i < nCount; ++i) {
+		pObject = ppObjects[i];
+		if (!pObject) {
+			continue;
+		}
+
+		oObjects.append(pObject);
+	}
+
+	return oObjects;
+}
+
+
+//-----------------------------------------------------------------------------
+// CEntityCollisionListenerManager class.
+//-----------------------------------------------------------------------------
+CEntityCollisionListenerManager::CEntityCollisionListenerManager():
+	m_bInitialized(false)
+{
+
+}
+
+void CEntityCollisionListenerManager::Initialize()
+{
+	if (m_bInitialized) {
+		return;
+	}
+
+	GetCollisionManager()->IncRef();
+	m_bInitialized = true;
+}
+
+void CEntityCollisionListenerManager::Finalize()
+{
+	if (!m_bInitialized) {
+		return;
+	}
+
+	GetCollisionManager()->DecRef();
+	m_bInitialized = false;
+}
+
+// Singleton accessor.
 static CEntityCollisionListenerManager s_OnEntityCollision;
 CEntityCollisionListenerManager *GetOnEntityCollisionListenerManager()
 {

--- a/src/core/modules/entities/entities_collisions.cpp
+++ b/src/core/modules/entities/entities_collisions.cpp
@@ -251,10 +251,15 @@ bool CCollisionManager::EnterScope(HookType_t eHookType, CHook *pHook)
 	void *pTable = *(void **)pFilter;
 	boost::unordered_map<void *, bool>::const_iterator it = s_mapTables.find(pTable);
 	if (it == s_mapTables.end()) {
-		s_mapTables[pTable] = GetType(pFilter)->IsDerivedFrom("CTraceFilterSimple");
+		if (GetType(pFilter)->IsDerivedFrom("CTraceFilterSimple")) {
+			s_mapTables[pTable] = true;
+			pWrapper = reinterpret_cast<CTraceFilterSimpleWrapper *>(pFilter);
+		}
+		else {
+			s_mapTables[pTable] = false;
+		}
 	}
-
-	if (s_mapTables[pTable]) {
+	else if (it->second) {
 		pWrapper = reinterpret_cast<CTraceFilterSimpleWrapper *>(pFilter);
 	}
 #endif

--- a/src/core/modules/entities/entities_collisions.cpp
+++ b/src/core/modules/entities/entities_collisions.cpp
@@ -228,7 +228,28 @@ bool CCollisionManager::EnterScope(HookType_t eHookType, CHook *pHook)
 	CollisionHookData_t hookData = pManager->m_mapHooks[pHook];
 
 	int nMask = pHook->GetArgument<int>(hookData.m_uiMaskIndex);
-	if (nMask != MASK_SOLID && nMask != MASK_PLAYERSOLID && nMask != MASK_NPCSOLID) {
+
+#if defined(ENGINE_CSGO)
+	if (nMask & CONTENTS_EMPTY ||
+		nMask & CONTENTS_AUX ||
+		nMask & CONTENTS_SLIME ||
+		nMask & CONTENTS_WATER ||
+		nMask & CONTENTS_BLOCKLOS ||
+		nMask & CONTENTS_OPAQUE ||
+		nMask & CONTENTS_IGNORE_NODRAW_OPAQUE ||
+		nMask & CONTENTS_CURRENT_0 || // CONTENTS_BRUSH_PAINT
+		nMask & CONTENTS_CURRENT_90 || // CONTENTS_GRENADECLIP
+		nMask & CONTENTS_DEBRIS ||
+		nMask & CONTENTS_DETAIL ||
+		nMask & CONTENTS_TRANSLUCENT ||
+		nMask & CONTENTS_HITBOX
+	) {
+#else
+	if (nMask != MASK_SOLID &&
+		nMask != MASK_PLAYERSOLID &&
+		nMask != MASK_NPCSOLID
+	) {
+#endif
 		pManager->m_vecScopes.push_back(scope);
 		return false;
 	}

--- a/src/core/modules/entities/entities_collisions.cpp
+++ b/src/core/modules/entities/entities_collisions.cpp
@@ -1,0 +1,41 @@
+/**
+* =============================================================================
+* Source Python
+* Copyright (C) 2012-2021 Source Python Development Team.  All rights reserved.
+* =============================================================================
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU General Public License, version 3.0, as published by the
+* Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+* details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+* As a special exception, the Source Python Team gives you permission
+* to link the code of this program (as well as its derivative works) to
+* "Half-Life 2," the "Source Engine," and any Game MODs that run on software
+* by the Valve Corporation.  You must obey the GNU General Public License in
+* all respects for all other code used.  Additionally, the Source.Python
+* Development Team grants this exception to all derivative works.
+*/
+
+//-----------------------------------------------------------------------------
+// Includes.
+//-----------------------------------------------------------------------------
+// Source.Python
+#include "modules/entities/entities_collisions.h"
+
+
+//-----------------------------------------------------------------------------
+// CEntityCollisionListenerManager's singleton accessor.
+//-----------------------------------------------------------------------------
+static CEntityCollisionListenerManager s_OnEntityCollision;
+CEntityCollisionListenerManager *GetOnEntityCollisionListenerManager()
+{
+	return &s_OnEntityCollision;
+}

--- a/src/core/modules/entities/entities_collisions.cpp
+++ b/src/core/modules/entities/entities_collisions.cpp
@@ -232,6 +232,7 @@ bool CCollisionManager::EnterScope(HookType_t eHookType, CHook *pHook)
 #if defined(ENGINE_CSGO)
 	if ((nMask & CONTENTS_EMPTY ||
 		nMask & CONTENTS_AUX ||
+		nMask & CONTENTS_GRATE ||
 		nMask & CONTENTS_SLIME ||
 		nMask & CONTENTS_WATER ||
 		nMask & CONTENTS_BLOCKLOS ||
@@ -242,7 +243,8 @@ bool CCollisionManager::EnterScope(HookType_t eHookType, CHook *pHook)
 		nMask & CONTENTS_DETAIL ||
 		nMask & CONTENTS_TRANSLUCENT ||
 		nMask & CONTENTS_HITBOX) &&
-		!(nMask & CONTENTS_CURRENT_90) // CONTENTS_GRENADECLIP
+		!(nMask & CONTENTS_CURRENT_90 || // CONTENTS_GRENADECLIP
+		nMask & CONTENTS_PLAYERCLIP)
 	) {
 #else
 	if (nMask != MASK_SOLID &&

--- a/src/core/modules/entities/entities_collisions.cpp
+++ b/src/core/modules/entities/entities_collisions.cpp
@@ -29,6 +29,7 @@
 //-----------------------------------------------------------------------------
 // Source.Python
 #include "modules/entities/entities_collisions.h"
+#include "utilities/conversions.h"
 
 #ifdef __linux__
 	#include "modules/memory/memory_rtti.h"
@@ -129,6 +130,13 @@ void CCollisionManager::UnregisterHash(ICollisionHash *pHash)
 	}
 
 	DecRef();
+}
+
+void CCollisionManager::OnNetworkedEntityDeleted(CBaseEntity *pEntity)
+{
+	FOR_EACH_VEC(m_vecHashes, i) {
+		m_vecHashes[i]->RemovePairs((void *)pEntity);
+	}
 }
 
 template<typename T>
@@ -412,6 +420,13 @@ CCollisionHash::~CCollisionHash()
 
 void CCollisionHash::AddPair(void *pObject, void *pOther)
 {
+	if (!IsValidNetworkedEntityPointer(pObject) || !IsValidNetworkedEntityPointer(pOther)) {
+		BOOST_RAISE_EXCEPTION(
+			PyExc_ValueError,
+			"Given entity pointer invalid or not networked."
+		)
+	}
+
 	m_pHash->AddObjectPair(pObject, pOther);
 }
 

--- a/src/core/modules/entities/entities_collisions.cpp
+++ b/src/core/modules/entities/entities_collisions.cpp
@@ -322,7 +322,7 @@ bool CCollisionManager::ShouldHitEntity(IHandleEntity *pHandleEntity, int conten
 	}
 
 	FOR_EACH_VEC(pManager->m_vecHashes, i) {
-		if (pManager->m_vecHashes[i]->IsPairInHash((void *)scope.m_pFilter->m_pPassEnt, (void *)pHandleEntity)) {
+		if (pManager->m_vecHashes[i]->HasPair((void *)scope.m_pFilter->m_pPassEnt, (void *)pHandleEntity)) {
 			return false;
 		}
 	}
@@ -389,7 +389,7 @@ bool CCollisionHash::IsInHash(void *pObject)
 	return m_pHash->IsObjectInHash(pObject);
 }
 
-bool CCollisionHash::IsPairInHash(void *pObject, void *pOther)
+bool CCollisionHash::HasPair(void *pObject, void *pOther)
 {
 	return m_pHash->IsObjectPairInHash(pObject, pOther);
 }

--- a/src/core/modules/entities/entities_collisions.h
+++ b/src/core/modules/entities/entities_collisions.h
@@ -92,7 +92,7 @@ public:
 	void RemovePairs(void *pObject);
 
 	bool IsInHash(void *pObject);
-	bool IsPairInHash(void *pObject, void *pOther);
+	bool HasPair(void *pObject, void *pOther);
 
 	list GetPairs(void *pObject);
 
@@ -170,12 +170,6 @@ private:
 
 // Singleton accessor.
 CEntityCollisionListenerManager *GetOnEntityCollisionListenerManager();
-
-
-//-----------------------------------------------------------------------------
-// Returns the current collision hash.
-//-----------------------------------------------------------------------------
-IPhysicsObjectPairHash *GetCollisionHash();
 
 
 #endif // _ENTITIES_COLLISIONS_H

--- a/src/core/modules/entities/entities_collisions.h
+++ b/src/core/modules/entities/entities_collisions.h
@@ -86,6 +86,8 @@ struct CollisionScope_t
 	CTraceFilterSimpleWrapper *m_pFilter;
 	ShouldHitFunc_t m_pExtraShouldHitCheckFunction;
 	CCollisionCache *m_pCache;
+	int m_nMask;
+	bool m_bSolidContents;
 };
 
 
@@ -167,11 +169,14 @@ private:
 class CCollisionManager
 {
 public:
+	friend CCollisionManager *GetCollisionManager();
 	friend class CEntityCollisionListenerManager;
 
-public:
+private:
 	CCollisionManager();
+	~CCollisionManager();
 
+public:
 	void Initialize();
 	void Finalize();
 
@@ -179,6 +184,9 @@ public:
 	void UnregisterHash(ICollisionHash *pHash);
 
 	void OnNetworkedEntityDeleted(CBaseEntity *pEntity);
+
+	void RegisterCollisionHook(object oCallback);
+	void UnregisterCollisionHook(object oCallback);
 
 protected:
 	void IncRef();
@@ -205,6 +213,8 @@ private:
 
 	int m_nTickCount;
 	CollisionCacheMap_t m_mapCache;
+
+	CListenerManager *m_pCollisionListener;
 };
 
 // Singleton accessor.

--- a/src/core/modules/entities/entities_collisions.h
+++ b/src/core/modules/entities/entities_collisions.h
@@ -186,10 +186,13 @@ public:
 	void RegisterHash(ICollisionHash *pHash);
 	void UnregisterHash(ICollisionHash *pHash);
 
+	void OnNetworkedEntityCreated(object oEntity);
 	void OnNetworkedEntityDeleted(CBaseEntity *pEntity);
 
 	void RegisterCollisionHook(object oCallback);
 	void UnregisterCollisionHook(object oCallback);
+
+	list GetSolidMasks();
 
 protected:
 	void IncRef();

--- a/src/core/modules/entities/entities_collisions.h
+++ b/src/core/modules/entities/entities_collisions.h
@@ -41,12 +41,14 @@
 
 // SDK
 #include "vphysics/object_hash.h"
+#include "bitvec.h"
 
 
 //-----------------------------------------------------------------------------
 // Forward declarations.
 //-----------------------------------------------------------------------------
 struct CollisionHookData_t;
+class CCollisionCache;
 
 
 //-----------------------------------------------------------------------------
@@ -57,6 +59,9 @@ struct CollisionHookData_t;
 #endif
 
 typedef boost::unordered_map<CHook *, CollisionHookData_t> CollisionHooksMap_t;
+
+typedef CBitVec<MAX_EDICTS> CollisionCache_t;
+typedef boost::unordered_map<unsigned int, CCollisionCache *> CollisionCacheMap_t;
 
 
 //-----------------------------------------------------------------------------
@@ -80,6 +85,7 @@ struct CollisionScope_t
 	unsigned int m_uiIndex;
 	CTraceFilterSimpleWrapper *m_pFilter;
 	ShouldHitFunc_t m_pExtraShouldHitCheckFunction;
+	CCollisionCache *m_pCache;
 };
 
 
@@ -141,6 +147,21 @@ private:
 
 
 //-----------------------------------------------------------------------------
+// CCollisionCache class.
+//-----------------------------------------------------------------------------
+class CCollisionCache : private CollisionCache_t
+{
+public:
+	bool HasResult(unsigned int uiIndex);
+	bool GetResult(unsigned int uiIndex);
+	void SetResult(unsigned int uiIndex, bool bResult);
+
+private:
+	CollisionCache_t m_vecCache;
+};
+
+
+//-----------------------------------------------------------------------------
 // CCollisionManager class.
 //-----------------------------------------------------------------------------
 class CCollisionManager
@@ -172,12 +193,18 @@ private:
 
 	static bool ShouldHitEntity(IHandleEntity *pHandleEntity, int contentsMask);
 
+	void RefreshCache();
+	CCollisionCache *GetCache(unsigned int uiIndex);
+
 private:
 	bool m_bInitialized;
 	unsigned int m_uiRefCount;
 	CUtlVector<ICollisionHash *> m_vecHashes;
 	CollisionHooksMap_t m_mapHooks;
 	std::vector<CollisionScope_t> m_vecScopes;
+
+	int m_nTickCount;
+	CollisionCacheMap_t m_mapCache;
 };
 
 // Singleton accessor.

--- a/src/core/modules/entities/entities_collisions.h
+++ b/src/core/modules/entities/entities_collisions.h
@@ -113,8 +113,8 @@ public:
 	ICollisionRules();
 	virtual ~ICollisionRules();
 
-	virtual void OnEntityDeleted(void *pEntity) = 0;
-	virtual bool ShouldHitEntity(void *pEntity, void *pOther) = 0;
+	virtual void OnEntityDeleted(CBaseEntity *pEntity) = 0;
+	virtual bool ShouldHitEntity(CBaseEntity *pEntity, CBaseEntity *pOther) = 0;
 
 	virtual void UnloadInstance();
 };
@@ -129,21 +129,45 @@ public:
 	CCollisionHash();
 	~CCollisionHash();
 
-	void OnEntityDeleted(void *pEntity);
-	bool ShouldHitEntity(void *pEntity, void *pOther);
+	void OnEntityDeleted(CBaseEntity *pEntity);
+	bool ShouldHitEntity(CBaseEntity *pEntity, CBaseEntity *pOther);
 
-	void AddPair(void *pEntity, void *pOther);
-	void RemovePair(void *pEntity, void *pOther);
-	void RemovePairs(void *pEntity);
+	void AddPair(CBaseEntityWrapper *pEntity, CBaseEntityWrapper *pOther);
+	void RemovePair(void *pObject, void *pOther);
+	void RemovePairs(void *pObject);
 
-	bool Contains(void *pEntity);
-	bool HasPair(void *pEntity, void *pOther);
+	bool Contains(void *pObject);
+	bool HasPair(void *pObject, void *pOther);
 
-	int GetCount(void *pEntity);
-	list GetPairs(void *pEntity);
+	int GetCount(void *pObject);
+	list GetPairs(void *pObject);
 
 private:
 	IPhysicsObjectPairHash *m_pHash;
+};
+
+
+//-----------------------------------------------------------------------------
+// CCollisionSet class.
+//-----------------------------------------------------------------------------
+class CCollisionSet : public ICollisionRules
+{
+public:
+	void Add(CBaseEntityWrapper *pEntity);
+	void Remove(void *pObject);
+	void Clear(void *pObject);
+
+	bool Contains(void *pObject);
+	unsigned int GetSize();
+	bool HasElements();
+
+	object Iterate();
+
+	void OnEntityDeleted(CBaseEntity *pEntity);
+	bool ShouldHitEntity(CBaseEntity *pEntity, CBaseEntity *pOther);
+
+private:
+	boost::unordered_set<void *> m_pSet;
 };
 
 
@@ -245,29 +269,9 @@ private:
 	bool m_bInitialized;
 };
 
-
-//-----------------------------------------------------------------------------
-// CEntityCollisionListenerManager class.
-//-----------------------------------------------------------------------------
-class CEntityCollisionListenerManager: public CCollisionListenerManager
-{
-
-};
-
-// Singleton accessor.
-CEntityCollisionListenerManager *GetOnEntityCollisionListenerManager();
-
-
-//-----------------------------------------------------------------------------
-// CPlayerCollisionListenerManager class.
-//-----------------------------------------------------------------------------
-class CPlayerCollisionListenerManager: public CCollisionListenerManager
-{
-
-};
-
-// Singleton accessor.
-CPlayerCollisionListenerManager *GetOnPlayerCollisionListenerManager();
+// Singleton accessors.
+CCollisionListenerManager *GetOnPlayerCollisionListenerManager();
+CCollisionListenerManager *GetOnEntityCollisionListenerManager();
 
 
 #endif // _ENTITIES_COLLISIONS_H

--- a/src/core/modules/entities/entities_collisions.h
+++ b/src/core/modules/entities/entities_collisions.h
@@ -105,36 +105,32 @@ struct CollisionHookData_t
 
 
 //-----------------------------------------------------------------------------
-// ICollisionHash class.
+// ICollisionRules class.
 //-----------------------------------------------------------------------------
-class ICollisionHash
+class ICollisionRules
 {
 public:
-	ICollisionHash();
-	virtual ~ICollisionHash();
+	ICollisionRules();
+	virtual ~ICollisionRules();
 
-	virtual void AddPair(void *pEntity, void *pOther) = 0;
-	virtual void RemovePair(void *pEntity, void *pOther) = 0;
-	virtual void RemovePairs(void *pEntity) = 0;
+	virtual void OnEntityDeleted(void *pEntity) = 0;
+	virtual bool ShouldHitEntity(void *pEntity, void *pOther) = 0;
 
-	virtual bool Contains(void *pEntity) = 0;
-	virtual bool HasPair(void *pEntity, void *pOther) = 0;
-
-	virtual int GetCount(void *pEntity) = 0;
-	virtual list GetPairs(void *pEntity) = 0;
-
-	void UnloadInstance();
+	virtual void UnloadInstance();
 };
 
 
 //-----------------------------------------------------------------------------
 // CCollisionHash class.
 //-----------------------------------------------------------------------------
-class CCollisionHash : public ICollisionHash
+class CCollisionHash : public ICollisionRules
 {
 public:
 	CCollisionHash();
 	~CCollisionHash();
+
+	void OnEntityDeleted(void *pEntity);
+	bool ShouldHitEntity(void *pEntity, void *pOther);
 
 	void AddPair(void *pEntity, void *pOther);
 	void RemovePair(void *pEntity, void *pOther);
@@ -183,8 +179,8 @@ public:
 	void Initialize();
 	void Finalize();
 
-	void RegisterHash(ICollisionHash *pHash);
-	void UnregisterHash(ICollisionHash *pHash);
+	void RegisterRules(ICollisionRules *pRules);
+	void UnregisterRules(ICollisionRules *pRules);
 
 	void OnNetworkedEntityCreated(object oEntity);
 	void OnNetworkedEntityDeleted(CBaseEntity *pEntity);
@@ -212,7 +208,7 @@ private:
 private:
 	bool m_bInitialized;
 	unsigned int m_uiRefCount;
-	CUtlVector<ICollisionHash *> m_vecHashes;
+	CUtlVector<ICollisionRules *> m_vecRules;
 	CollisionHooksMap_t m_mapHooks;
 	std::vector<CollisionScope_t> m_vecScopes;
 

--- a/src/core/modules/entities/entities_collisions.h
+++ b/src/core/modules/entities/entities_collisions.h
@@ -94,9 +94,32 @@ struct CollisionHookData_t
 
 
 //-----------------------------------------------------------------------------
+// ICollisionHash class.
+//-----------------------------------------------------------------------------
+class ICollisionHash
+{
+public:
+	ICollisionHash();
+	virtual ~ICollisionHash();
+
+	virtual void AddPair(void *pObject, void *pOther) = 0;
+	virtual void RemovePair(void *pObject, void *pOther) = 0;
+	virtual void RemovePairs(void *pObject) = 0;
+
+	virtual bool IsInHash(void *pObject) = 0;
+	virtual bool HasPair(void *pObject, void *pOther) = 0;
+
+	virtual int GetCount(void *pObject) = 0;
+	virtual list GetPairs(void *pObject) = 0;
+
+	void UnloadInstance();
+};
+
+
+//-----------------------------------------------------------------------------
 // CCollisionHash class.
 //-----------------------------------------------------------------------------
-class CCollisionHash
+class CCollisionHash : public ICollisionHash
 {
 public:
 	CCollisionHash();
@@ -111,8 +134,6 @@ public:
 
 	int GetCount(void *pObject);
 	list GetPairs(void *pObject);
-
-	void UnloadInstance();
 
 private:
 	IPhysicsObjectPairHash *m_pHash;
@@ -133,8 +154,8 @@ public:
 	void Initialize();
 	void Finalize();
 
-	void RegisterHash(CCollisionHash *pHash);
-	void UnregisterHash(CCollisionHash *pHash);
+	void RegisterHash(ICollisionHash *pHash);
+	void UnregisterHash(ICollisionHash *pHash);
 
 protected:
 	void IncRef();
@@ -158,7 +179,7 @@ private:
 private:
 	bool m_bInitialized;
 	unsigned int m_uiRefCount;
-	CUtlVector<CCollisionHash *> m_vecHashes;
+	CUtlVector<ICollisionHash *> m_vecHashes;
 	CollisionHooksMap_t m_mapHooks;
 	std::vector<CollisionScope_t> m_vecScopes;
 };

--- a/src/core/modules/entities/entities_collisions.h
+++ b/src/core/modules/entities/entities_collisions.h
@@ -163,13 +163,7 @@ protected:
 
 private:
 	template<typename T>
-	static CHook *GetHook(T tFunc, const char *szDebugName);
-
-	template<typename T>
 	void RegisterHook(T tFunc, unsigned int uiFilterIndex, unsigned int nMaskIndex, const char *szDebugName);
-
-	template<typename T>
-	void UnregisterHook(T tFunc, const char *szDebugName);
 
 	static bool EnterScope(HookType_t eHookType, CHook *pHook);
 	static bool ExitScope(HookType_t eHookType, CHook *pHook);

--- a/src/core/modules/entities/entities_collisions.h
+++ b/src/core/modules/entities/entities_collisions.h
@@ -110,7 +110,7 @@ struct CollisionHookData_t
 class ICollisionRules
 {
 public:
-	ICollisionRules();
+	ICollisionRules(bool bRegister = true);
 	virtual ~ICollisionRules();
 
 	virtual void OnEntityDeleted(CBaseEntity *pEntity) = 0;
@@ -153,6 +153,9 @@ private:
 class CCollisionSet : public ICollisionRules
 {
 public:
+	CCollisionSet();
+	CCollisionSet(bool bRegister);
+
 	void Add(CBaseEntityWrapper *pEntity);
 	void Remove(void *pObject);
 	void Clear(void *pObject);
@@ -168,6 +171,31 @@ public:
 
 private:
 	boost::unordered_set<void *> m_pSet;
+};
+
+
+//-----------------------------------------------------------------------------
+// CCollisionMap class.
+//-----------------------------------------------------------------------------
+class CCollisionMap: public ICollisionRules
+{
+public:
+	void OnEntityDeleted(CBaseEntity *pEntity);
+	bool ShouldHitEntity(CBaseEntity *pEntity, CBaseEntity *pOther);
+
+	boost::shared_ptr<CCollisionSet> Find(CBaseEntityWrapper *pEntity);
+
+	void Remove(void *pObject);
+	void Clear();
+
+	bool Contains(void *pObject);
+	unsigned int GetSize();
+	bool HasElements();
+
+	object Iterate();
+
+private:
+	boost::unordered_map<void *, boost::shared_ptr<CCollisionSet> > m_mapSets;
 };
 
 

--- a/src/core/modules/entities/entities_collisions.h
+++ b/src/core/modules/entities/entities_collisions.h
@@ -41,7 +41,12 @@
 
 // SDK
 #include "vphysics/object_hash.h"
-#include "tier1/utlmap.h"
+
+
+//-----------------------------------------------------------------------------
+// Forward declarations.
+//-----------------------------------------------------------------------------
+struct CollisionHookData_t;
 
 
 //-----------------------------------------------------------------------------
@@ -51,7 +56,7 @@
 	typedef bool (*ShouldHitFunc_t)( IHandleEntity *pHandleEntity, int contentsMask );
 #endif
 
-typedef boost::unordered_map<CHook *, unsigned int> CollisionHooksMap_t;
+typedef boost::unordered_map<CHook *, CollisionHookData_t> CollisionHooksMap_t;
 
 
 //-----------------------------------------------------------------------------
@@ -79,6 +84,16 @@ struct CollisionScope_t
 
 
 //-----------------------------------------------------------------------------
+// CollisionHookData_t structure.
+//-----------------------------------------------------------------------------
+struct CollisionHookData_t
+{
+	unsigned int m_uiFilterIndex;
+	unsigned int m_uiMaskIndex;
+};
+
+
+//-----------------------------------------------------------------------------
 // CCollisionHash class.
 //-----------------------------------------------------------------------------
 class CCollisionHash
@@ -94,7 +109,10 @@ public:
 	bool IsInHash(void *pObject);
 	bool HasPair(void *pObject, void *pOther);
 
+	int GetCount(void *pObject);
 	list GetPairs(void *pObject);
+
+	void UnloadInstance();
 
 private:
 	IPhysicsObjectPairHash *m_pHash;
@@ -124,10 +142,10 @@ protected:
 
 private:
 	template<typename T>
-	CHook *GetHook(T tFunc, const char *szDebugName);
+	static CHook *GetHook(T tFunc, const char *szDebugName);
 
 	template<typename T>
-	void RegisterHook(T tFunc, unsigned int uiFilterIndex, const char *szDebugName);
+	void RegisterHook(T tFunc, unsigned int uiFilterIndex, unsigned int nMaskIndex, const char *szDebugName);
 
 	template<typename T>
 	void UnregisterHook(T tFunc, const char *szDebugName);

--- a/src/core/modules/entities/entities_collisions.h
+++ b/src/core/modules/entities/entities_collisions.h
@@ -1,0 +1,249 @@
+/**
+* =============================================================================
+* Source Python
+* Copyright (C) 2012-2021 Source Python Development Team.  All rights reserved.
+* =============================================================================
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU General Public License, version 3.0, as published by the
+* Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+* details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+* As a special exception, the Source Python Team gives you permission
+* to link the code of this program (as well as its derivative works) to
+* "Half-Life 2," the "Source Engine," and any Game MODs that run on software
+* by the Valve Corporation.  You must obey the GNU General Public License in
+* all respects for all other code used.  Additionally, the Source.Python
+* Development Team grants this exception to all derivative works.
+*/
+
+#ifndef _ENTITIES_COLLISIONS_H
+#define _ENTITIES_COLLISIONS_H
+
+//-----------------------------------------------------------------------------
+// Includes.
+//-----------------------------------------------------------------------------
+// Source.Python
+#include "sp_main.h"
+#include "utilities/wrap_macros.h"
+#include "modules/listeners/listeners_manager.h"
+#include "modules/memory/memory_pointer.h"
+#include "modules/memory/memory_function_info.h"
+
+// SDK
+#include "engine/IEngineTrace.h"
+
+
+//---------------------------------------------------------------------------------
+// Externals.
+//---------------------------------------------------------------------------------
+extern IEngineTrace *enginetrace;
+
+
+//-----------------------------------------------------------------------------
+// Typedefs.
+//-----------------------------------------------------------------------------
+typedef bool (*ShouldHitFunc_t)(IHandleEntity *pEntity, int iMask);
+
+
+//-----------------------------------------------------------------------------
+// Forward declarations.
+//-----------------------------------------------------------------------------
+class CEntityCollisionListenerManager;
+CEntityCollisionListenerManager *GetOnEntityCollisionListenerManager();
+
+
+//-----------------------------------------------------------------------------
+// CTraceFilterSimpleWrapper class.
+//-----------------------------------------------------------------------------
+class CTraceFilterSimpleWrapper : public CTraceFilter
+{
+public:
+	const IHandleEntity *m_pPassEnt;
+	int m_collisionGroup;
+	ShouldHitFunc_t m_pExtraShouldHitCheckFunction;
+};
+
+
+//-----------------------------------------------------------------------------
+// TraceRayScope_t structure.
+//-----------------------------------------------------------------------------
+struct TraceRayScope_t
+{
+	unsigned int m_uiIndex;
+	CTraceFilterSimpleWrapper *m_pFilter;
+	ShouldHitFunc_t m_pExtraShouldHitCheckFunction;
+};
+
+
+//-----------------------------------------------------------------------------
+// CEntityCollisionListenerManager class.
+//-----------------------------------------------------------------------------
+class CEntityCollisionListenerManager: public CListenerManager
+{
+public:
+	CEntityCollisionListenerManager():
+		m_pHook(NULL)
+	{
+
+	}
+
+	virtual void Initialize()
+	{
+		if (m_pHook) {
+			return;
+		}
+
+		CFunctionInfo *pInfo = GetFunctionInfo(&IEngineTrace::TraceRay);
+		if (!pInfo) {
+			BOOST_RAISE_EXCEPTION(
+				PyExc_ValueError,
+				"Failed to retrieve IEngineTrace::TraceRay's info."
+			)
+		}
+
+		CFunction *pFunc = CPointer((unsigned long)((void *)enginetrace)).MakeVirtualFunction(*pInfo);
+		delete pInfo;
+
+		if (!pFunc || !pFunc->IsHookable()) {
+			BOOST_RAISE_EXCEPTION(
+				PyExc_ValueError,
+				"IEngineTrace::TraceRay's function is invalid or not hookable."
+			)
+		}
+
+		void *pAddr = (void *)pFunc->m_ulAddr;
+		m_pHook = GetHookManager()->FindHook(pAddr);
+		if (!m_pHook) {
+			m_pHook = GetHookManager()->HookFunction(pAddr, pFunc->m_pCallingConvention);
+			if (!m_pHook) {
+				BOOST_RAISE_EXCEPTION(
+					PyExc_ValueError,
+					"Failed to hook IEngineTrace::TraceRay."
+				)
+			}
+		}
+
+		delete pFunc;
+		m_pHook->AddCallback(
+			HOOKTYPE_PRE,
+			(HookHandlerFn *)&CEntityCollisionListenerManager::_pre_trace_ray
+		);
+
+		m_pHook->AddCallback(
+			HOOKTYPE_POST,
+			(HookHandlerFn *)&CEntityCollisionListenerManager::_post_trace_ray
+		);
+	}
+
+	virtual void Finalize()
+	{
+		if (!m_pHook) {
+			return;
+		}
+
+		m_pHook->RemoveCallback(
+			HOOKTYPE_PRE,
+			(HookHandlerFn *)&CEntityCollisionListenerManager::_pre_trace_ray
+		);
+
+		m_pHook = NULL;
+	}
+
+	static bool _pre_trace_ray(HookType_t eHookType, CHook *pHook)
+	{
+		CTraceFilterSimple *pFilter = dynamic_cast<CTraceFilterSimple *>(pHook->GetArgument<ITraceFilter *>(3));
+		if (!pFilter || !((CTraceFilterSimpleWrapper *)pFilter)->m_pPassEnt) {
+			return false;
+		}
+
+		const CBaseHandle &pHandle = ((CTraceFilterSimpleWrapper *)pFilter)->m_pPassEnt->GetRefEHandle();
+		if (!pHandle.IsValid()) {
+			return false;
+		}
+
+		TraceRayScope_t scope;
+		scope.m_uiIndex = pHandle.GetEntryIndex();
+		scope.m_pFilter = (CTraceFilterSimpleWrapper *)pFilter;
+		scope.m_pExtraShouldHitCheckFunction = scope.m_pFilter->m_pExtraShouldHitCheckFunction;
+		scope.m_pFilter->m_pExtraShouldHitCheckFunction = (ShouldHitFunc_t)CEntityCollisionListenerManager::_should_collide;
+
+		static CEntityCollisionListenerManager *pManager = GetOnEntityCollisionListenerManager();
+		pManager->m_vecScopes.push_back(scope);
+
+		return false;
+	}
+
+	static bool _should_collide(IHandleEntity *pHandleEntity, int iMask)
+	{
+		static CEntityCollisionListenerManager *pManager = GetOnEntityCollisionListenerManager();
+		if (pManager->m_vecScopes.empty()) {
+			return true;
+		}
+
+		const CBaseHandle &pHandle = pHandleEntity->GetRefEHandle();
+		if (!pHandle.IsValid()) {
+			return true;
+		}
+
+		TraceRayScope_t scope = pManager->m_vecScopes.back();
+		if (scope.m_pExtraShouldHitCheckFunction) {
+			if (scope.m_pExtraShouldHitCheckFunction != scope.m_pFilter->m_pExtraShouldHitCheckFunction) {
+				if (!(scope.m_pExtraShouldHitCheckFunction(pHandleEntity, iMask))) {
+					return false;
+				}
+			}
+		}
+
+		static object Entity = import("entities").attr("entity").attr("Entity");
+		object oEntity = Entity(scope.m_uiIndex);
+		object oOther = Entity(pHandle.GetEntryIndex());
+
+		bool bResult = true;
+		FOR_EACH_VEC(pManager->m_vecCallables, i) {
+			BEGIN_BOOST_PY()
+				object oResult = pManager->m_vecCallables[i](oEntity, oOther);
+				if (!oResult.is_none() && !extract<bool>(oResult)) {
+					bResult = false;
+				}
+			END_BOOST_PY_NORET()
+		}
+
+		return bResult;
+	}
+
+	static bool _post_trace_ray(HookType_t eHookType, CHook *pHook)
+	{
+		static CEntityCollisionListenerManager *pManager = GetOnEntityCollisionListenerManager();
+		if (pManager->m_vecScopes.empty()) {
+			return false;
+		}
+
+		TraceRayScope_t scope = pManager->m_vecScopes.back();
+		pManager->m_vecScopes.pop_back();
+
+		if (scope.m_pExtraShouldHitCheckFunction) {
+			scope.m_pFilter->m_pExtraShouldHitCheckFunction = scope.m_pExtraShouldHitCheckFunction;
+			scope.m_pExtraShouldHitCheckFunction = NULL;
+		}
+
+		return false;
+	}
+
+public:
+	CHook *m_pHook;
+	std::vector<TraceRayScope_t> m_vecScopes;
+};
+
+// Singleton accessor.
+CEntityCollisionListenerManager *GetOnEntityCollisionListenerManager();
+
+
+#endif // _ENTITIES_COLLISIONS_H

--- a/src/core/modules/entities/entities_collisions.h
+++ b/src/core/modules/entities/entities_collisions.h
@@ -33,6 +33,7 @@
 // Source.Python
 #include "sp_main.h"
 #include "modules/listeners/listeners_manager.h"
+#include "modules/entities/entities_entity.h"
 #include "modules/physics/physics.h"
 #include "modules/memory/memory_hooks.h"
 
@@ -84,6 +85,7 @@ struct CollisionScope_t
 {
 	bool m_bSkip;
 	unsigned int m_uiIndex;
+	bool m_bIsPlayer;
 	CTraceFilterSimpleWrapper *m_pFilter;
 	ShouldHitFunc_t m_pExtraShouldHitCheckFunction;
 	CCollisionCache *m_pCache;
@@ -171,7 +173,7 @@ class CCollisionManager
 {
 public:
 	friend CCollisionManager *GetCollisionManager();
-	friend class CEntityCollisionListenerManager;
+	friend class CCollisionListenerManager;
 
 private:
 	CCollisionManager();
@@ -228,22 +230,45 @@ inline CCollisionManager *GetCollisionManager()
 
 
 //-----------------------------------------------------------------------------
-// CEntityCollisionListenerManager class.
+// CCollisionListenerManager class.
 //-----------------------------------------------------------------------------
-class CEntityCollisionListenerManager: public CListenerManager
+class CCollisionListenerManager : public CListenerManager
 {
 public:
-	CEntityCollisionListenerManager();
+	CCollisionListenerManager();
 
 	void Initialize();
 	void Finalize();
+
+	bool CallCallbacks(object oEntity, object oOther);
 
 private:
 	bool m_bInitialized;
 };
 
+
+//-----------------------------------------------------------------------------
+// CEntityCollisionListenerManager class.
+//-----------------------------------------------------------------------------
+class CEntityCollisionListenerManager: public CCollisionListenerManager
+{
+
+};
+
 // Singleton accessor.
 CEntityCollisionListenerManager *GetOnEntityCollisionListenerManager();
+
+
+//-----------------------------------------------------------------------------
+// CPlayerCollisionListenerManager class.
+//-----------------------------------------------------------------------------
+class CPlayerCollisionListenerManager: public CCollisionListenerManager
+{
+
+};
+
+// Singleton accessor.
+CPlayerCollisionListenerManager *GetOnPlayerCollisionListenerManager();
 
 
 #endif // _ENTITIES_COLLISIONS_H

--- a/src/core/modules/entities/entities_collisions.h
+++ b/src/core/modules/entities/entities_collisions.h
@@ -38,6 +38,7 @@
 
 // Boost
 #include "boost/unordered_map.hpp"
+#include "boost/unordered_set.hpp"
 
 // SDK
 #include "vphysics/object_hash.h"
@@ -110,15 +111,15 @@ public:
 	ICollisionHash();
 	virtual ~ICollisionHash();
 
-	virtual void AddPair(void *pObject, void *pOther) = 0;
-	virtual void RemovePair(void *pObject, void *pOther) = 0;
-	virtual void RemovePairs(void *pObject) = 0;
+	virtual void AddPair(void *pEntity, void *pOther) = 0;
+	virtual void RemovePair(void *pEntity, void *pOther) = 0;
+	virtual void RemovePairs(void *pEntity) = 0;
 
-	virtual bool IsInHash(void *pObject) = 0;
-	virtual bool HasPair(void *pObject, void *pOther) = 0;
+	virtual bool Contains(void *pEntity) = 0;
+	virtual bool HasPair(void *pEntity, void *pOther) = 0;
 
-	virtual int GetCount(void *pObject) = 0;
-	virtual list GetPairs(void *pObject) = 0;
+	virtual int GetCount(void *pEntity) = 0;
+	virtual list GetPairs(void *pEntity) = 0;
 
 	void UnloadInstance();
 };
@@ -133,15 +134,15 @@ public:
 	CCollisionHash();
 	~CCollisionHash();
 
-	void AddPair(void *pObject, void *pOther);
-	void RemovePair(void *pObject, void *pOther);
-	void RemovePairs(void *pObject);
+	void AddPair(void *pEntity, void *pOther);
+	void RemovePair(void *pEntity, void *pOther);
+	void RemovePairs(void *pEntity);
 
-	bool IsInHash(void *pObject);
-	bool HasPair(void *pObject, void *pOther);
+	bool Contains(void *pEntity);
+	bool HasPair(void *pEntity, void *pOther);
 
-	int GetCount(void *pObject);
-	list GetPairs(void *pObject);
+	int GetCount(void *pEntity);
+	list GetPairs(void *pEntity);
 
 private:
 	IPhysicsObjectPairHash *m_pHash;
@@ -201,7 +202,6 @@ private:
 
 	static bool ShouldHitEntity(IHandleEntity *pHandleEntity, int contentsMask);
 
-	void RefreshCache();
 	CCollisionCache *GetCache(unsigned int uiIndex);
 
 private:
@@ -211,10 +211,12 @@ private:
 	CollisionHooksMap_t m_mapHooks;
 	std::vector<CollisionScope_t> m_vecScopes;
 
+	boost::unordered_set<unsigned long> m_setSolidMasks;
+
 	int m_nTickCount;
 	CollisionCacheMap_t m_mapCache;
 
-	CListenerManager *m_pCollisionListener;
+	CListenerManager *m_pCollisionHooks;
 };
 
 // Singleton accessor.

--- a/src/core/modules/entities/entities_collisions.h
+++ b/src/core/modules/entities/entities_collisions.h
@@ -157,6 +157,8 @@ public:
 	void RegisterHash(ICollisionHash *pHash);
 	void UnregisterHash(ICollisionHash *pHash);
 
+	void OnNetworkedEntityDeleted(CBaseEntity *pEntity);
+
 protected:
 	void IncRef();
 	void DecRef();

--- a/src/core/modules/entities/entities_collisions.h
+++ b/src/core/modules/entities/entities_collisions.h
@@ -49,6 +49,7 @@
 // Forward declarations.
 //-----------------------------------------------------------------------------
 struct CollisionHookData_t;
+class CCollisionSet;
 class CCollisionCache;
 
 
@@ -65,6 +66,7 @@ typedef CBitVec<MAX_EDICTS> CollisionCache_t;
 typedef boost::unordered_map<unsigned int, CCollisionCache *> CollisionCacheMap_t;
 
 typedef std::pair<void *, void *> CollisionPair_t;
+typedef boost::unordered_map<void *, boost::shared_ptr<CCollisionSet> > CollisionMap_t;
 
 
 //-----------------------------------------------------------------------------
@@ -181,7 +183,7 @@ public:
 
 	void Add(CBaseEntityWrapper *pEntity);
 	void Remove(void *pObject);
-	void Clear(void *pObject);
+	void Clear();
 
 	bool Contains(void *pObject);
 	unsigned int GetSize();
@@ -218,7 +220,7 @@ public:
 	object Iterate();
 
 private:
-	boost::unordered_map<void *, boost::shared_ptr<CCollisionSet> > m_mapSets;
+	CollisionMap_t m_mapSets;
 };
 
 

--- a/src/core/modules/entities/entities_collisions_wrap.cpp
+++ b/src/core/modules/entities/entities_collisions_wrap.cpp
@@ -1,0 +1,94 @@
+/**
+* =============================================================================
+* Source Python
+* Copyright (C) 2012-2021 Source Python Development Team.  All rights reserved.
+* =============================================================================
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU General Public License, version 3.0, as published by the
+* Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+* details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+* As a special exception, the Source Python Team gives you permission
+* to link the code of this program (as well as its derivative works) to
+* "Half-Life 2," the "Source Engine," and any Game MODs that run on software
+* by the Valve Corporation.  You must obey the GNU General Public License in
+* all respects for all other code used.  Additionally, the Source.Python
+* Development Team grants this exception to all derivative works.
+*/
+
+//-----------------------------------------------------------------------------
+// Includes.
+//-----------------------------------------------------------------------------
+// Source.Python
+#include "export_main.h"
+#include "modules/entities/entities_collisions.h"
+
+
+//-----------------------------------------------------------------------------
+// Forward declarations.
+//-----------------------------------------------------------------------------
+static void export_entity_collision_hash(scope);
+
+
+//-----------------------------------------------------------------------------
+// Declare the _entities._collisions module.
+//-----------------------------------------------------------------------------
+DECLARE_SP_SUBMODULE(_entities, _collisions)
+{
+	export_entity_collision_hash(_collisions);
+}
+
+
+//-----------------------------------------------------------------------------
+// Exports CCollisionHash.
+//-----------------------------------------------------------------------------
+void export_entity_collision_hash(scope _collisions)
+{
+	class_<CCollisionHash> CollisionHash("CollisionHash");
+
+	// Methods...
+	CollisionHash.def(
+		"add_pair",
+		&CCollisionHash::AddPair,
+		"Adds the given pair to the hash."
+	);
+
+	CollisionHash.def(
+		"remove_pair",
+		&CCollisionHash::RemovePair,
+		"Removes the given pair from the hash."
+	);
+
+	CollisionHash.def(
+		"remove_pairs",
+		&CCollisionHash::RemovePairs,
+		"Removes all pair associated with the given object."
+	);
+
+	CollisionHash.def(
+		"is_pair_in_hash",
+		&CCollisionHash::IsPairInHash,
+		"Returns whether the given pairs is in the hash."
+	);
+
+	CollisionHash.def(
+		"get_pairs",
+		&CCollisionHash::GetPairs,
+		"Returns a list of all objects associated with the given object."
+	);
+
+	// Special methods...
+	CollisionHash.def(
+		"__contains__",
+		&CCollisionHash::IsInHash,
+		"Returns whether the given object is in the hash."
+	);
+}

--- a/src/core/modules/entities/entities_collisions_wrap.cpp
+++ b/src/core/modules/entities/entities_collisions_wrap.cpp
@@ -71,6 +71,13 @@ void export_collision_manager(scope _collisions)
 		"Unregisters a collision hook."
 	);
 
+	// Properties...
+	CollisionManager.add_property(
+		"solid_masks",
+		&CCollisionManager::GetSolidMasks,
+		"Returns a list containing the masks that are currently considered solid."
+	);
+
 	// Singleton...
 	_collisions.attr("collision_manager") = object(ptr(GetCollisionManager()));
 }

--- a/src/core/modules/entities/entities_collisions_wrap.cpp
+++ b/src/core/modules/entities/entities_collisions_wrap.cpp
@@ -39,6 +39,7 @@ static void export_collision_manager(scope);
 static void export_collision_rules(scope);
 static void export_collision_hash(scope);
 static void export_collision_set(scope);
+static void export_collision_map(scope);
 
 
 //-----------------------------------------------------------------------------
@@ -50,6 +51,7 @@ DECLARE_SP_SUBMODULE(_entities, _collisions)
 	export_collision_rules(_collisions);
 	export_collision_hash(_collisions);
 	export_collision_set(_collisions);
+	export_collision_map(_collisions);
 }
 
 
@@ -169,7 +171,7 @@ void export_collision_hash(scope _collisions)
 //-----------------------------------------------------------------------------
 void export_collision_set(scope _collisions)
 {
-	class_<CCollisionSet, bases<ICollisionRules> > CollisionSet(
+	class_<CCollisionSet, boost::shared_ptr<CCollisionSet>, bases<ICollisionRules> > CollisionSet(
 		"CollisionSet",
 		"Collision rules where contained elements never collide with anything."
 	);
@@ -216,5 +218,61 @@ void export_collision_set(scope _collisions)
 		"__len__",
 		&CCollisionSet::GetSize,
 		"Returns the amount of elements contained in the set."
+	);
+}
+
+
+//-----------------------------------------------------------------------------
+// Exports CCollisionMap.
+//-----------------------------------------------------------------------------
+void export_collision_map(scope _collisions)
+{
+	class_<CCollisionMap, bases<ICollisionRules> > CollisionMap(
+		"CollisionMap",
+		"Collision rules that overrides one-way collisions."
+	);
+
+	// Methods...
+	CollisionMap.def(
+		"clear",
+		&CCollisionMap::Clear,
+		"Removes all elements from the map."
+	);
+
+	// Special methods...
+	CollisionMap.def(
+		"__getitem__",
+		&CCollisionMap::Find,
+		"Returns the collision set associated with the given entity."
+	);
+
+	CollisionMap.def(
+		"__delitem__",
+		&CCollisionMap::Remove,
+		"Removes the collision set associated with the given entity."
+	);
+
+	CollisionMap.def(
+		"__bool__",
+		&CCollisionMap::HasElements,
+		"Returns whether the map is empty or not."
+	);
+
+	CollisionMap.def(
+		"__contains__",
+		&CCollisionMap::Contains,
+		"Returns whether the given element is in the map or not."
+	);
+
+	CollisionMap.def(
+		"__len__",
+		&CCollisionMap::GetSize,
+		"Returns the amount of elements contained in the map."
+	);
+
+	CollisionMap.def(
+		"__iter__",
+		&CCollisionMap::Iterate,
+		"Iterates over all elements contained in the map."
 	);
 }

--- a/src/core/modules/entities/entities_collisions_wrap.cpp
+++ b/src/core/modules/entities/entities_collisions_wrap.cpp
@@ -80,6 +80,12 @@ void export_entity_collision_hash(scope _collisions)
 	);
 
 	CollisionHash.def(
+		"get_count",
+		&CCollisionHash::GetCount,
+		"Returns the amount of pairs associated with the given object."
+	);
+
+	CollisionHash.def(
 		"get_pairs",
 		&CCollisionHash::GetPairs,
 		"Returns a list of all objects associated with the given object."
@@ -90,5 +96,12 @@ void export_entity_collision_hash(scope _collisions)
 		"__contains__",
 		&CCollisionHash::IsInHash,
 		"Returns whether the given object is in the hash."
+	);
+
+	// AutoUnload...
+	CollisionHash.def(
+		"_unload_instance",
+		&CCollisionHash::UnloadInstance,
+		"Called when an instance is being unloaded."
 	);
 }

--- a/src/core/modules/entities/entities_collisions_wrap.cpp
+++ b/src/core/modules/entities/entities_collisions_wrap.cpp
@@ -74,8 +74,8 @@ void export_entity_collision_hash(scope _collisions)
 	);
 
 	CollisionHash.def(
-		"is_pair_in_hash",
-		&CCollisionHash::IsPairInHash,
+		"has_pair",
+		&CCollisionHash::HasPair,
 		"Returns whether the given pairs is in the hash."
 	);
 

--- a/src/core/modules/entities/entities_collisions_wrap.cpp
+++ b/src/core/modules/entities/entities_collisions_wrap.cpp
@@ -36,7 +36,7 @@
 // Forward declarations.
 //-----------------------------------------------------------------------------
 static void export_collision_manager(scope);
-static void export_base_collision_hash(scope);
+static void export_collision_rules(scope);
 static void export_collision_hash(scope);
 
 
@@ -46,13 +46,13 @@ static void export_collision_hash(scope);
 DECLARE_SP_SUBMODULE(_entities, _collisions)
 {
 	export_collision_manager(_collisions);
-	export_base_collision_hash(_collisions);
+	export_collision_rules(_collisions);
 	export_collision_hash(_collisions);
 }
 
 
 //-----------------------------------------------------------------------------
-// Exports ICollisionHash.
+// Exports CCollisionManager.
 //-----------------------------------------------------------------------------
 void export_collision_manager(scope _collisions)
 {
@@ -84,60 +84,23 @@ void export_collision_manager(scope _collisions)
 
 
 //-----------------------------------------------------------------------------
-// Exports ICollisionHash.
+// Exports ICollisionRules.
 //-----------------------------------------------------------------------------
-void export_base_collision_hash(scope _collisions)
+void export_collision_rules(scope _collisions)
 {
-	class_<ICollisionHash, boost::noncopyable> BaseCollisionHash("BaseCollisionHash", no_init);
+	class_<ICollisionRules, boost::noncopyable> CollisionRules("CollisionRules", no_init);
 
 	// Methods...
-	BaseCollisionHash.def(
-		"add_pair",
-		&ICollisionHash::AddPair,
-		"Adds the given entity pair to the hash."
-	);
-
-	BaseCollisionHash.def(
-		"remove_pair",
-		&ICollisionHash::RemovePair,
-		"Removes the given pair from the hash."
-	);
-
-	BaseCollisionHash.def(
-		"remove_pairs",
-		&ICollisionHash::RemovePairs,
-		"Removes all pairs associated with the given entity."
-	);
-
-	BaseCollisionHash.def(
-		"has_pair",
-		&ICollisionHash::HasPair,
-		"Returns whether the given pair is in the hash."
-	);
-
-	BaseCollisionHash.def(
-		"get_count",
-		&ICollisionHash::GetCount,
-		"Returns the amount of pairs associated with the given entity."
-	);
-
-	BaseCollisionHash.def(
-		"get_pairs",
-		&ICollisionHash::GetPairs,
-		"Returns a list of all entities associated with the given entity."
-	);
-
-	// Special methods...
-	BaseCollisionHash.def(
-		"__contains__",
-		&ICollisionHash::Contains,
-		"Returns whether the given entity is in the hash."
+	CollisionRules.def(
+		"should_hit_entity",
+		&ICollisionRules::ShouldHitEntity,
+		"Returns whether the given entities should collide with each other."
 	);
 
 	// AutoUnload...
-	BaseCollisionHash.def(
+	CollisionRules.def(
 		"_unload_instance",
-		&ICollisionHash::UnloadInstance,
+		&ICollisionRules::UnloadInstance,
 		"Called when an instance is being unloaded."
 	);
 }
@@ -148,5 +111,49 @@ void export_base_collision_hash(scope _collisions)
 //-----------------------------------------------------------------------------
 void export_collision_hash(scope _collisions)
 {
-	class_<CCollisionHash, bases<ICollisionHash> >("CollisionHash");
+	class_<CCollisionHash, bases<ICollisionRules> > CollisionHash("CollisionHash");
+
+	// Methods...
+	CollisionHash.def(
+		"add_pair",
+		&CCollisionHash::AddPair,
+		"Adds the given entity pair to the hash."
+	);
+
+	CollisionHash.def(
+		"remove_pair",
+		&CCollisionHash::RemovePair,
+		"Removes the given pair from the hash."
+	);
+
+	CollisionHash.def(
+		"remove_pairs",
+		&CCollisionHash::RemovePairs,
+		"Removes all pairs associated with the given entity."
+	);
+
+	CollisionHash.def(
+		"has_pair",
+		&CCollisionHash::HasPair,
+		"Returns whether the given pair is in the hash."
+	);
+
+	CollisionHash.def(
+		"get_count",
+		&CCollisionHash::GetCount,
+		"Returns the amount of pairs associated with the given entity."
+	);
+
+	CollisionHash.def(
+		"get_pairs",
+		&CCollisionHash::GetPairs,
+		"Returns a list of all entities associated with the given entity."
+	);
+
+	// Special methods...
+	CollisionHash.def(
+		"__contains__",
+		&CCollisionHash::Contains,
+		"Returns whether the given entity is in the hash."
+	);
 }

--- a/src/core/modules/entities/entities_collisions_wrap.cpp
+++ b/src/core/modules/entities/entities_collisions_wrap.cpp
@@ -52,56 +52,59 @@ DECLARE_SP_SUBMODULE(_entities, _collisions)
 //-----------------------------------------------------------------------------
 void export_entity_collision_hash(scope _collisions)
 {
-	class_<CCollisionHash> CollisionHash("CollisionHash");
+	class_<ICollisionHash, boost::noncopyable> BaseCollisionHash("BaseCollisionHash", no_init);
 
 	// Methods...
-	CollisionHash.def(
+	BaseCollisionHash.def(
 		"add_pair",
-		&CCollisionHash::AddPair,
+		&ICollisionHash::AddPair,
 		"Adds the given pair to the hash."
 	);
 
-	CollisionHash.def(
+	BaseCollisionHash.def(
 		"remove_pair",
-		&CCollisionHash::RemovePair,
+		&ICollisionHash::RemovePair,
 		"Removes the given pair from the hash."
 	);
 
-	CollisionHash.def(
+	BaseCollisionHash.def(
 		"remove_pairs",
-		&CCollisionHash::RemovePairs,
+		&ICollisionHash::RemovePairs,
 		"Removes all pair associated with the given object."
 	);
 
-	CollisionHash.def(
+	BaseCollisionHash.def(
 		"has_pair",
-		&CCollisionHash::HasPair,
+		&ICollisionHash::HasPair,
 		"Returns whether the given pairs is in the hash."
 	);
 
-	CollisionHash.def(
+	BaseCollisionHash.def(
 		"get_count",
-		&CCollisionHash::GetCount,
+		&ICollisionHash::GetCount,
 		"Returns the amount of pairs associated with the given object."
 	);
 
-	CollisionHash.def(
+	BaseCollisionHash.def(
 		"get_pairs",
-		&CCollisionHash::GetPairs,
+		&ICollisionHash::GetPairs,
 		"Returns a list of all objects associated with the given object."
 	);
 
 	// Special methods...
-	CollisionHash.def(
+	BaseCollisionHash.def(
 		"__contains__",
-		&CCollisionHash::IsInHash,
+		&ICollisionHash::IsInHash,
 		"Returns whether the given object is in the hash."
 	);
 
 	// AutoUnload...
-	CollisionHash.def(
+	BaseCollisionHash.def(
 		"_unload_instance",
-		&CCollisionHash::UnloadInstance,
+		&ICollisionHash::UnloadInstance,
 		"Called when an instance is being unloaded."
 	);
+
+	// CCollisionHash...
+	class_<CCollisionHash, bases<ICollisionHash> >("CollisionHash");
 }

--- a/src/core/modules/entities/entities_collisions_wrap.cpp
+++ b/src/core/modules/entities/entities_collisions_wrap.cpp
@@ -38,6 +38,7 @@
 static void export_collision_manager(scope);
 static void export_collision_rules(scope);
 static void export_collision_hash(scope);
+static void export_collision_set(scope);
 
 
 //-----------------------------------------------------------------------------
@@ -48,6 +49,7 @@ DECLARE_SP_SUBMODULE(_entities, _collisions)
 	export_collision_manager(_collisions);
 	export_collision_rules(_collisions);
 	export_collision_hash(_collisions);
+	export_collision_set(_collisions);
 }
 
 
@@ -111,7 +113,10 @@ void export_collision_rules(scope _collisions)
 //-----------------------------------------------------------------------------
 void export_collision_hash(scope _collisions)
 {
-	class_<CCollisionHash, bases<ICollisionRules> > CollisionHash("CollisionHash");
+	class_<CCollisionHash, bases<ICollisionRules> > CollisionHash(
+		"CollisionHash",
+		"Collision rules where contained pairs never collide with each other."
+	);
 
 	// Methods...
 	CollisionHash.def(
@@ -155,5 +160,61 @@ void export_collision_hash(scope _collisions)
 		"__contains__",
 		&CCollisionHash::Contains,
 		"Returns whether the given entity is in the hash."
+	);
+}
+
+
+//-----------------------------------------------------------------------------
+// Exports CCollisionSet.
+//-----------------------------------------------------------------------------
+void export_collision_set(scope _collisions)
+{
+	class_<CCollisionSet, bases<ICollisionRules> > CollisionSet(
+		"CollisionSet",
+		"Collision rules where contained elements never collide with anything."
+	);
+
+	// Methods...
+	CollisionSet.def(
+		"add",
+		&CCollisionSet::Add,
+		"Adds the given element to the set."
+	);
+
+	CollisionSet.def(
+		"remove",
+		&CCollisionSet::Remove,
+		"Removes the given element from the set."
+	);
+
+	CollisionSet.def(
+		"clear",
+		&CCollisionSet::Clear,
+		"Removes all elements from the set."
+	);
+
+	// Special methods...
+	CollisionSet.def(
+		"__bool__",
+		&CCollisionSet::HasElements,
+		"Returns whether the set is empty or not."
+	);
+
+	CollisionSet.def(
+		"__contains__",
+		&CCollisionSet::Contains,
+		"Returns whether the given element is in the set or not."
+	);
+
+	CollisionSet.def(
+		"__iter__",
+		&CCollisionSet::Iterate,
+		"Iterates over all elements contained in the set."
+	);
+
+	CollisionSet.def(
+		"__len__",
+		&CCollisionSet::GetSize,
+		"Returns the amount of elements contained in the set."
 	);
 }

--- a/src/core/modules/entities/entities_collisions_wrap.cpp
+++ b/src/core/modules/entities/entities_collisions_wrap.cpp
@@ -157,11 +157,23 @@ void export_collision_hash(scope _collisions)
 		"Returns a list of all entities associated with the given entity."
 	);
 
+	CollisionHash.def(
+		"clear",
+		&CCollisionHash::Clear,
+		"Removes all elements from the hash."
+	);
+
 	// Special methods...
 	CollisionHash.def(
 		"__contains__",
 		&CCollisionHash::Contains,
 		"Returns whether the given entity is in the hash."
+	);
+
+	CollisionHash.def(
+		"__len__",
+		&CCollisionHash::GetSize,
+		"Returns the size of the collision hash."
 	);
 }
 

--- a/src/core/modules/entities/entities_collisions_wrap.cpp
+++ b/src/core/modules/entities/entities_collisions_wrap.cpp
@@ -35,7 +35,9 @@
 //-----------------------------------------------------------------------------
 // Forward declarations.
 //-----------------------------------------------------------------------------
-static void export_entity_collision_hash(scope);
+static void export_collision_manager(scope);
+static void export_base_collision_hash(scope);
+static void export_collision_hash(scope);
 
 
 //-----------------------------------------------------------------------------
@@ -43,14 +45,41 @@ static void export_entity_collision_hash(scope);
 //-----------------------------------------------------------------------------
 DECLARE_SP_SUBMODULE(_entities, _collisions)
 {
-	export_entity_collision_hash(_collisions);
+	export_collision_manager(_collisions);
+	export_base_collision_hash(_collisions);
+	export_collision_hash(_collisions);
 }
 
 
 //-----------------------------------------------------------------------------
-// Exports CCollisionHash.
+// Exports ICollisionHash.
 //-----------------------------------------------------------------------------
-void export_entity_collision_hash(scope _collisions)
+void export_collision_manager(scope _collisions)
+{
+	class_<CCollisionManager, boost::noncopyable> CollisionManager("CollisionManager", no_init);
+
+	// Methods...
+	CollisionManager.def(
+		"register_hook",
+		&CCollisionManager::RegisterCollisionHook,
+		"Registers a collision hook."
+	);
+
+	CollisionManager.def(
+		"unregister_hook",
+		&CCollisionManager::UnregisterCollisionHook,
+		"Unregisters a collision hook."
+	);
+
+	// Singleton...
+	_collisions.attr("collision_manager") = object(ptr(GetCollisionManager()));
+}
+
+
+//-----------------------------------------------------------------------------
+// Exports ICollisionHash.
+//-----------------------------------------------------------------------------
+void export_base_collision_hash(scope _collisions)
 {
 	class_<ICollisionHash, boost::noncopyable> BaseCollisionHash("BaseCollisionHash", no_init);
 
@@ -104,7 +133,13 @@ void export_entity_collision_hash(scope _collisions)
 		&ICollisionHash::UnloadInstance,
 		"Called when an instance is being unloaded."
 	);
+}
 
-	// CCollisionHash...
+
+//-----------------------------------------------------------------------------
+// Exports CCollisionHash.
+//-----------------------------------------------------------------------------
+void export_collision_hash(scope _collisions)
+{
 	class_<CCollisionHash, bases<ICollisionHash> >("CollisionHash");
 }

--- a/src/core/modules/entities/entities_collisions_wrap.cpp
+++ b/src/core/modules/entities/entities_collisions_wrap.cpp
@@ -87,7 +87,7 @@ void export_base_collision_hash(scope _collisions)
 	BaseCollisionHash.def(
 		"add_pair",
 		&ICollisionHash::AddPair,
-		"Adds the given pair to the hash."
+		"Adds the given entity pair to the hash."
 	);
 
 	BaseCollisionHash.def(
@@ -99,32 +99,32 @@ void export_base_collision_hash(scope _collisions)
 	BaseCollisionHash.def(
 		"remove_pairs",
 		&ICollisionHash::RemovePairs,
-		"Removes all pair associated with the given object."
+		"Removes all pairs associated with the given entity."
 	);
 
 	BaseCollisionHash.def(
 		"has_pair",
 		&ICollisionHash::HasPair,
-		"Returns whether the given pairs is in the hash."
+		"Returns whether the given pair is in the hash."
 	);
 
 	BaseCollisionHash.def(
 		"get_count",
 		&ICollisionHash::GetCount,
-		"Returns the amount of pairs associated with the given object."
+		"Returns the amount of pairs associated with the given entity."
 	);
 
 	BaseCollisionHash.def(
 		"get_pairs",
 		&ICollisionHash::GetPairs,
-		"Returns a list of all objects associated with the given object."
+		"Returns a list of all entities associated with the given entity."
 	);
 
 	// Special methods...
 	BaseCollisionHash.def(
 		"__contains__",
-		&ICollisionHash::IsInHash,
-		"Returns whether the given object is in the hash."
+		&ICollisionHash::Contains,
+		"Returns whether the given entity is in the hash."
 	);
 
 	// AutoUnload...

--- a/src/core/modules/entities/entities_entity.cpp
+++ b/src/core/modules/entities/entities_entity.cpp
@@ -486,6 +486,11 @@ bool CBaseEntityWrapper::IsWeapon()
 	return result;
 }
 
+bool CBaseEntityWrapper::IsNetworked()
+{
+	return IServerUnknownExt::IsNetworked((IServerUnknown *)this);
+}
+
 IPhysicsObjectWrapper* CBaseEntityWrapper::GetPhysicsObject()
 {
 	return Wrap<IPhysicsObjectWrapper>(GetDatamapProperty<IPhysicsObject*>("m_pPhysicsObject"));

--- a/src/core/modules/entities/entities_entity.h
+++ b/src/core/modules/entities/entities_entity.h
@@ -316,6 +316,8 @@ public:
 	bool IsPlayer();
 	bool IsWeapon();
 
+	bool IsNetworked();
+
 	Vector GetOrigin();
 	void SetOrigin(Vector& vec);
 

--- a/src/core/modules/entities/entities_entity.h
+++ b/src/core/modules/entities/entities_entity.h
@@ -445,4 +445,43 @@ public:
 };
 
 
+//-----------------------------------------------------------------------------
+// Returns an entity pointer as a Python object.
+//-----------------------------------------------------------------------------
+inline object GetEntityObject(CBaseEntityWrapper *pEntity)
+{
+	if (pEntity->IsNetworked()) {
+		if (pEntity->IsPlayer()) {
+			static object Player = import("players").attr("entity").attr("Player");
+			return Player(pEntity->GetIndex());
+		}
+
+		if (pEntity->IsWeapon()) {
+			static object Weapon = import("weapons").attr("entity").attr("Weapon");
+			return Weapon(pEntity->GetIndex());
+		}
+
+		static object Entity = import("entities").attr("entity").attr("Entity");
+		return Entity(pEntity->GetIndex());
+	}
+
+	return object(ptr(pEntity));
+}
+
+inline object GetEntityObject(CBaseEntity *pEntity)
+{
+	return GetEntityObject((CBaseEntityWrapper *)pEntity);
+}
+
+inline object GetEntityObject(unsigned int uiIndex)
+{
+	CBaseEntity *pEntity;
+	if (!BaseEntityFromIndex(uiIndex, pEntity)) {
+		return object();
+	}
+
+	return GetEntityObject((CBaseEntityWrapper *)pEntity);
+}
+
+
 #endif // _ENTITIES_ENTITY_H

--- a/src/core/modules/listeners/listeners_wrap.cpp
+++ b/src/core/modules/listeners/listeners_wrap.cpp
@@ -30,6 +30,7 @@
 #include "export_main.h"
 #include "utilities/wrap_macros.h"
 #include "listeners_manager.h"
+#include "modules/entities/entities_collisions.h"
 
 
 //-----------------------------------------------------------------------------
@@ -172,6 +173,7 @@ void export_listener_managers(scope _listeners)
 	_listeners.attr("on_networked_entity_spawned_listener_manager") = object(ptr(GetOnNetworkedEntitySpawnedListenerManager()));
 	_listeners.attr("on_entity_deleted_listener_manager") = object(ptr(GetOnEntityDeletedListenerManager()));
 	_listeners.attr("on_networked_entity_deleted_listener_manager") = object(ptr(GetOnNetworkedEntityDeletedListenerManager()));
+	_listeners.attr("on_entity_collision_listener_manager") = object(ptr((CListenerManager *)GetOnEntityCollisionListenerManager()));
 
 	_listeners.attr("on_data_loaded_listener_manager") = object(ptr(GetOnDataLoadedListenerManager()));
 	_listeners.attr("on_combiner_pre_cache_listener_manager") = object(ptr(GetOnCombinerPreCacheListenerManager()));

--- a/src/core/modules/listeners/listeners_wrap.cpp
+++ b/src/core/modules/listeners/listeners_wrap.cpp
@@ -174,6 +174,7 @@ void export_listener_managers(scope _listeners)
 	_listeners.attr("on_entity_deleted_listener_manager") = object(ptr(GetOnEntityDeletedListenerManager()));
 	_listeners.attr("on_networked_entity_deleted_listener_manager") = object(ptr(GetOnNetworkedEntityDeletedListenerManager()));
 	_listeners.attr("on_entity_collision_listener_manager") = object(ptr((CListenerManager *)GetOnEntityCollisionListenerManager()));
+	_listeners.attr("on_player_collision_listener_manager") = object(ptr((CListenerManager *)GetOnPlayerCollisionListenerManager()));
 
 	_listeners.attr("on_data_loaded_listener_manager") = object(ptr(GetOnDataLoadedListenerManager()));
 	_listeners.attr("on_combiner_pre_cache_listener_manager") = object(ptr(GetOnCombinerPreCacheListenerManager()));

--- a/src/core/modules/memory/memory_hooks.h
+++ b/src/core/modules/memory/memory_hooks.h
@@ -54,7 +54,7 @@ public:
 	{ return m_pHook->GetRegisters(); }
 
 	str	__repr__()
-	{ return str(tuple(ptr(this))); }
+	{ return str(boost::python::tuple(ptr(this))); }
 
 	void* GetReturnAddress()
 	{

--- a/src/core/sp_main.cpp
+++ b/src/core/sp_main.cpp
@@ -647,16 +647,20 @@ void CSourcePython::OnEntityCreated( CBaseEntity *pEntity )
 
 	CALL_LISTENERS(OnEntityCreated, ptr((CBaseEntityWrapper*) pEntity));
 
-	GET_LISTENER_MANAGER(OnNetworkedEntityCreated, on_networked_entity_created_manager);
-	if (!on_networked_entity_created_manager->GetCount())
-		return;
-
 	unsigned int uiIndex;
 	if (!IndexFromBaseEntity(pEntity, uiIndex))
 		return;
 
 	static object Entity = import("entities").attr("entity").attr("Entity");
-	CALL_LISTENERS_WITH_MNGR(on_networked_entity_created_manager, Entity(uiIndex));
+	object oEntity = Entity(uiIndex);
+	
+	GET_LISTENER_MANAGER(OnNetworkedEntityCreated, on_networked_entity_created_manager);
+	if (on_networked_entity_created_manager->GetCount()) {
+		CALL_LISTENERS_WITH_MNGR(on_networked_entity_created_manager, oEntity);
+	}
+
+	static CCollisionManager *pCollisionManager = GetCollisionManager();
+	pCollisionManager->OnNetworkedEntityCreated(oEntity);
 }
 
 void CSourcePython::OnEntitySpawned( CBaseEntity *pEntity )

--- a/src/core/sp_main.cpp
+++ b/src/core/sp_main.cpp
@@ -700,7 +700,7 @@ void CSourcePython::OnEntityDeleted( CBaseEntity *pEntity )
 
 	// Cleanup active collision hashes.
 	static CCollisionManager *pCollisionManager = GetCollisionManager();
-	pCollisionManager->OnNetworkedEntityDeleted(pEntity);
+	pCollisionManager->OnNetworkedEntityDeleted((CBaseEntityWrapper *)pEntity);
 }
 
 void CSourcePython::OnDataLoaded( MDLCacheDataType_t type, MDLHandle_t handle )

--- a/src/core/sp_main.cpp
+++ b/src/core/sp_main.cpp
@@ -60,6 +60,7 @@
 #include "modules/listeners/listeners_manager.h"
 #include "utilities/conversions.h"
 #include "modules/entities/entities_entity.h"
+#include "modules/entities/entities_collisions.h"
 #include "modules/core/core.h"
 
 #ifdef _WIN32
@@ -692,6 +693,10 @@ void CSourcePython::OnEntityDeleted( CBaseEntity *pEntity )
 	// Invalidate the internal entity cache once all callbacks have been called.
 	static object _on_networked_entity_deleted = import("entities").attr("_base").attr("_on_networked_entity_deleted");
 	_on_networked_entity_deleted(uiIndex);
+
+	// Cleanup active collision hashes.
+	static CCollisionManager *pCollisionManager = GetCollisionManager();
+	pCollisionManager->OnNetworkedEntityDeleted(pEntity);
 }
 
 void CSourcePython::OnDataLoaded( MDLCacheDataType_t type, MDLHandle_t handle )

--- a/src/core/sp_python.cpp
+++ b/src/core/sp_python.cpp
@@ -310,6 +310,32 @@ struct baseentity_from_python
 	}
 };
 
+struct baseentity_index_from_python
+{
+	baseentity_index_from_python()
+	{
+		boost::python::converter::registry::insert(
+			&convert,
+			boost::python::type_id<CBaseEntity>()
+		);
+
+		boost::python::converter::registry::insert(
+			&convert,
+			boost::python::type_id<CBaseEntityWrapper>()
+		);
+	}
+
+	static void* convert(PyObject* obj)
+	{
+		extract<unsigned int> extractor(obj);
+		if (!extractor.check()) {
+			return NULL;
+		}
+
+		return (void *)ExcBaseEntityFromIndex(extractor());
+	}
+};
+
 // void*
 struct void_ptr_to_python
 {
@@ -364,6 +390,7 @@ void InitConverters()
 
 	baseentity_to_python();
 	baseentity_from_python();
+	baseentity_index_from_python();
 	
 	void_ptr_to_python();
 	void_ptr_from_python();


### PR DESCRIPTION
```python
from listeners import OnPlayerCollision

@OnPlayerCollision
def on_player_collision(player, entity):
    """Called when a player is about to collide with an entity."""
    # Disable teammates collisions
    if not entity.is_player():
        return
    return player.team_index != entity.team_index
```

```python
from listeners import OnEntityCollision

@OnEntityCollision
def on_entity_collision(entity, other):
    """Called when a non-player entity is about to collide with another entity."""
    # Disable weapons/projectiles collisions with everything except players
    return not (entity.is_weapon() and not other.is_player())
```

```python
from entities.collisions import CollisionHash
from events import Event
from players.entity import Player

h = CollisionHash()

@Event('player_say')
def player_say(game_event):
    player = Player.from_userid(game_event['userid'])
    entity = player.view_entity
    if entity is None:
        return
    # Toggle collisions with aimed entity
    if h.has_pair(player, entity):
        h.remove_pair(player, entity)
    else:
        h.add_pair(player, entity)
```

```python
from entities.collisions import CollisionSet
from events import Event
from players.entity import Player

s = CollisionSet()

@Event('player_say')
def player_say(game_event):
    player = Player.from_userid(game_event['userid'])
    # Toggle collisions with everything
    if player in s:
        s.remove(player)
    else:
        s.add(player)
```

```python
from entities.collisions import CollisionMap
from events import Event
from players.entity import Player

m = CollisionMap()

@Event('player_say')
def player_say(game_event):
    player = Player.from_userid(game_event['userid'])
    entity = player.view_entity
    if entity is None:
        return
    # Toggle one-way collisions with aimed entity
    s = m[player]
    if entity in s:
        s.remove(entity)
    else:
        s.add(entity)
```

```python
from entities.collisions import CollisionMap
from entities.collisions import CollisionMode
from events import Event
from players.entity import Player

# Setting the collision mode to ALLOW rather than PREVENT will negate the rules.
m = CollisionMap(CollisionMode.ALLOW)

@Event('player_say')
def player_say(game_event):
    player = Player.from_userid(game_event['userid'])
    entity = player.view_entity
    if entity is None:
        return
    s = m[player]
    if entity in s:
        s.remove(entity.index)
    else:
        # Player will now collide with nothing except this entity
        s.add(entity)
```

```python
from engines.trace import ContentFlags
from entities.collisions import CollisionHook

@CollisionHook
def collision_hook(entity, other, trace_filter, mask):
    """Called whenever two entities are tested for colliding contents."""
    # Prevent hostages from being killed by bullets
    if not mask & ContentFlags.HITBOX:
        return
    return other.classname != 'hostage_entity'
```