### PR TITLE
Allow to hide information about pages in the menu

### DIFF
--- a/addons/source-python/packages/source-python/menus/base.py
+++ b/addons/source-python/packages/source-python/menus/base.py
@@ -421,6 +421,21 @@ def _translate_text(text, player_index):
     return text
 
 
+def _format_paged_title(menu, player_index, page):
+    buffer = ''
+
+    if menu.title:
+        buffer += _translate_text(menu.title, player_index)
+
+    if menu.show_pages:
+        if buffer:
+            buffer += ' '
+
+        buffer += f'[{page.index + 1}/{menu.page_count}]'
+
+    return buffer
+
+
 # =============================================================================
 # >> LISTENERS
 # =============================================================================

--- a/addons/source-python/packages/source-python/menus/esc.py
+++ b/addons/source-python/packages/source-python/menus/esc.py
@@ -16,6 +16,7 @@ from keyvalues import KeyValues
 from menus.base import _BaseMenu
 from menus.base import _PagedMenuBase
 from menus.base import _BaseOption
+from menus.base import _format_paged_title
 from menus.base import _translate_text
 from menus.queue import ESC_SELECTION_CMD
 from menus.queue import _esc_queues
@@ -169,7 +170,7 @@ class PagedESCMenu(SimpleESCMenu, _PagedMenuBase):
     def __init__(
             self, data=None, select_callback=None, build_callback=None, close_callback=None,
             description=None, title=None, title_color=WHITE, fill=True,
-            parent_menu=None):
+            parent_menu=None, show_pages=True):
         """Initialize the object.
 
         :param iterable|None data: See :meth:`menus.base._BaseMenu.__init__`.
@@ -192,6 +193,7 @@ class PagedESCMenu(SimpleESCMenu, _PagedMenuBase):
             description, title, title_color)
         self.fill = fill
         self.parent_menu = parent_menu
+        self.show_pages = show_pages
 
     @staticmethod
     def _get_max_item_count():
@@ -205,16 +207,8 @@ class PagedESCMenu(SimpleESCMenu, _PagedMenuBase):
         :param _PlayerPage page: The player's current page.
         :param KeyValues data: The current menu data.
         """
-        # Create the page info string
-        info = '[{0}/{1}]'.format(page.index + 1, self.page_count)
-
-        if self.title is not None:
-            data.set_string('title', '{0} {1}'.format(
-                _translate_text(self.title, player_index), info))
-        else:
-            data.set_string('title', info)
-
-        data.set_color('color', self.title_color)
+        buffer = _format_paged_title(self, player_index, page)
+        data.set_string('title', buffer)
 
     def _format_body(self, player_index, page, data):
         """Prepare the body for the menu.
@@ -316,7 +310,7 @@ class ListESCMenu(PagedESCMenu):
     def __init__(
             self, data=None, select_callback=None, build_callback=None, close_callback=None,
             description=None, title=None, title_color=WHITE, fill=True,
-            parent_menu=None, items_per_page=5):
+            parent_menu=None, items_per_page=5, show_pages=True):
         """Initialize the object.
 
         :param iterable|None data: See :meth:`menus.base._BaseMenu.__init__`.
@@ -335,7 +329,7 @@ class ListESCMenu(PagedESCMenu):
             on a single page (5 is the maximum).
         """
         super().__init__(data, select_callback, build_callback, close_callback, description,
-            title, title_color, fill, parent_menu)
+            title, title_color, fill, parent_menu, show_pages)
         self.items_per_page = items_per_page
 
     def _get_max_item_count(self):

--- a/addons/source-python/packages/source-python/menus/radio.py
+++ b/addons/source-python/packages/source-python/menus/radio.py
@@ -141,7 +141,7 @@ class PagedRadioMenu(SimpleRadioMenu, _PagedMenuBase):
             self, data=None, select_callback=None,
             build_callback=None, close_callback=None, description=None,
             title=None, top_separator='-' * 30, bottom_separator='-' * 30,
-            fill=True, parent_menu=None):
+            fill=True, parent_menu=None, show_pages=True):
         """Initialize the object.
 
         :param iterable|None data: See :meth:`menus.base._BaseMenu.__init__`.
@@ -172,6 +172,7 @@ class PagedRadioMenu(SimpleRadioMenu, _PagedMenuBase):
         self.bottom_separator = bottom_separator
         self.fill = fill
         self.parent_menu = parent_menu
+        self.show_pages = show_pages
 
     @staticmethod
     def _get_max_item_count():
@@ -186,11 +187,20 @@ class PagedRadioMenu(SimpleRadioMenu, _PagedMenuBase):
         :param slots: A set to which slots can be added.
         :type slots: :class:`set`
         """
-        # Create the page info string
-        info = '[{0}/{1}]\n'.format(page.index + 1, self.page_count)
 
-        buffer = '{0} {1}'.format(_translate_text(
-            self.title, player_index), info) if self.title else info
+        translated_title = _translate_text(self.title, player_index) if self.title else ''
+        page_info = '[{0}/{1}]'.format(page.index + 1, self.page_count) if self.show_pages else ''
+
+        if translated_title and page_info:
+            buffer = '{0} {1}'.format(translated_title, page_info)
+        elif translated_title:
+            buffer = translated_title
+        elif page_info:
+            buffer = page_info
+        else:
+            buffer = ''
+
+        buffer += '\n'
 
         # Set description if present
         if self.description is not None:
@@ -325,7 +335,7 @@ class ListRadioMenu(PagedRadioMenu):
             self, data=None, select_callback=None, build_callback=None, close_callback=None,
             description=None, title=None, top_separator='-' * 30,
             bottom_separator='-' * 30, fill=True, parent_menu=None,
-            items_per_page=10):
+            items_per_page=10, show_pages=True):
         """Initialize the object.
 
         :param iterable|None data: See :meth:`menus.base._BaseMenu.__init__`.
@@ -345,7 +355,7 @@ class ListRadioMenu(PagedRadioMenu):
             on a single page.
         """
         super().__init__(data, select_callback, build_callback, close_callback, description,
-            title, top_separator, bottom_separator, fill, parent_menu)
+            title, top_separator, bottom_separator, fill, parent_menu, show_pages)
         self.items_per_page = items_per_page
 
     def _get_max_item_count(self):

--- a/addons/source-python/packages/source-python/menus/radio.py
+++ b/addons/source-python/packages/source-python/menus/radio.py
@@ -13,6 +13,7 @@ from menus.base import Text
 from menus.base import _BaseMenu
 from menus.base import _PagedMenuBase
 from menus.base import _BaseOption
+from menus.base import _format_paged_title
 from menus.base import _translate_text
 from menus.queue import _radio_queues
 #   Messages
@@ -187,16 +188,7 @@ class PagedRadioMenu(SimpleRadioMenu, _PagedMenuBase):
         :param slots: A set to which slots can be added.
         :type slots: :class:`set`
         """
-        buffer = ''
-
-        if self.title:
-            buffer += _translate_text(self.title, player_index)
-
-        if self.show_pages:
-            if buffer:
-                buffer += ' '
-
-            buffer += f'[{page.index + 1}/{self.page_count}]'
+        buffer = _format_paged_title(self, player_index, page)
 
         if buffer:
             buffer += '\n'

--- a/addons/source-python/packages/source-python/menus/radio.py
+++ b/addons/source-python/packages/source-python/menus/radio.py
@@ -193,9 +193,13 @@ class PagedRadioMenu(SimpleRadioMenu, _PagedMenuBase):
             buffer += _translate_text(self.title, player_index)
 
         if self.show_pages:
-            buffer += f' [{page.index + 1}/{self.page_count}]'
+            if buffer:
+                buffer += ' '
 
-        buffer = buffer.strip() + '\n'
+            buffer += f'[{page.index + 1}/{self.page_count}]'
+
+        if buffer:
+            buffer += '\n'
 
         # Set description if present
         if self.description is not None:

--- a/addons/source-python/packages/source-python/menus/radio.py
+++ b/addons/source-python/packages/source-python/menus/radio.py
@@ -187,20 +187,15 @@ class PagedRadioMenu(SimpleRadioMenu, _PagedMenuBase):
         :param slots: A set to which slots can be added.
         :type slots: :class:`set`
         """
+        buffer = ''
 
-        translated_title = _translate_text(self.title, player_index) if self.title else ''
-        page_info = '[{0}/{1}]'.format(page.index + 1, self.page_count) if self.show_pages else ''
+        if self.title:
+            buffer += _translate_text(self.title, player_index)
 
-        if translated_title and page_info:
-            buffer = '{0} {1}'.format(translated_title, page_info)
-        elif translated_title:
-            buffer = translated_title
-        elif page_info:
-            buffer = page_info
-        else:
-            buffer = ''
+        if self.show_pages:
+            buffer += f' [{page.index + 1}/{self.page_count}]'
 
-        buffer += '\n'
+        buffer = buffer.strip() + '\n'
 
         # Set description if present
         if self.description is not None:


### PR DESCRIPTION
Sometimes it is not necessary to show navigation, for example, in the admin menu (as in SM)