### PR TITLE
Fixed ExtractAddress causing Segmentation fault if it received None object. (#481)

### DIFF
--- a/src/core/modules/filters/filters_recipients.h
+++ b/src/core/modules/filters/filters_recipients.h
@@ -114,7 +114,7 @@ public:
 		object self = cls();
 		object add_recipient = self.attr("add_recipient");
 
-		IRecipientFilter *pFilter = (IRecipientFilter *)ExtractAddress(oPtr);
+		IRecipientFilter *pFilter = (IRecipientFilter *)ExtractAddress(oPtr, true);
 		for (int i=0; i < pFilter->GetRecipientCount(); i++) {
 			add_recipient(pFilter->GetRecipientIndex(i));
 		}

--- a/src/core/modules/memory/memory_utilities.h
+++ b/src/core/modules/memory/memory_utilities.h
@@ -65,6 +65,9 @@
 // ============================================================================
 inline unsigned long ExtractAddress(object oPtr, bool bValidate = false)
 {
+	if (oPtr.is_none())
+		BOOST_RAISE_EXCEPTION(PyExc_ValueError, "None was passed, expected Pointer(0) or NULL.")
+
 	CPointer* pPtr;
 
 	extract<CPointer *> extractor(oPtr);

--- a/src/core/modules/memory/memory_utilities.h
+++ b/src/core/modules/memory/memory_utilities.h
@@ -65,9 +65,6 @@
 // ============================================================================
 inline unsigned long ExtractAddress(object oPtr, bool bValidate = false)
 {
-	if (oPtr.is_none())
-		BOOST_RAISE_EXCEPTION(PyExc_ValueError, "None was passed, expected Pointer(0) or NULL.")
-
 	CPointer* pPtr;
 
 	extract<CPointer *> extractor(oPtr);
@@ -80,6 +77,9 @@ inline unsigned long ExtractAddress(object oPtr, bool bValidate = false)
 	{
 		pPtr = extractor();
 	}
+
+	if (!pPtr)
+		BOOST_RAISE_EXCEPTION(PyExc_ValueError, "None was passed, expected NULL or Pointer(0).")
 
 	if (bValidate)
 		pPtr->Validate();


### PR DESCRIPTION
#481