### PR TITLE
Removed unnecessary _BaseSound._unload_instance function.

### DIFF
--- a/addons/source-python/packages/source-python/engines/precache.py
+++ b/addons/source-python/packages/source-python/engines/precache.py
@@ -113,13 +113,7 @@ class _PrecacheBase(AutoUnload):
         self._precache()
 
     def _unload_instance(self):
-        """Remove from the downloads list and unregister server_spawn."""
-        # Remove the path from the downloads list
-        try:
-            self._downloads._unload_instance()
-        except AttributeError:
-            pass
-
+        """Unregister server_spawn."""
         # Unregister the server_spawn event
         event_manager.unregister_for_event('server_spawn', self._server_spawn)
 

--- a/addons/source-python/packages/source-python/engines/sound.py
+++ b/addons/source-python/packages/source-python/engines/sound.py
@@ -21,8 +21,6 @@ from mutagen import mp3
 from mutagen import oggvorbis
 
 # Source.Python Imports
-#   Core
-from core import WeakAutoUnload
 #   Engines
 from engines import engines_logger
 #   Entities
@@ -100,7 +98,7 @@ class Attenuation(float, Enum):
 # =============================================================================
 # >> CLASSES
 # =============================================================================
-class _BaseSound(WeakAutoUnload):
+class _BaseSound:
     """Base class for sound classes."""
 
     # Set the base _downloads attribute to know whether

--- a/addons/source-python/packages/source-python/engines/sound.py
+++ b/addons/source-python/packages/source-python/engines/sound.py
@@ -285,11 +285,6 @@ class _BaseSound(WeakAutoUnload):
         self._duration = value
         return value
 
-    def _unload_instance(self):
-        """Remove the sample from the downloads list."""
-        if self._downloads is not None:
-            self._downloads._unload_instance()
-
 
 class Sound(_BaseSound):
     """Class used to interact with precached sounds.


### PR DESCRIPTION
This fixes the following error when unloading the plugin

Output:
```
[Source.Python]
[SP] Caught an Exception:
Traceback (most recent call last):
  File "..\addons\source-python\packages\source-python\plugins\manager.py", line 437, in _unload_auto_unload_instances
    instance._unload_instance()
  File "..\addons\source-python\packages\source-python\engines\sound.py", line 292, in _unload_instance
    self._downloads._unload_instance()
  File "..\addons\source-python\packages\source-python\stringtables\downloads.py", line 98, in _unload_instance
    _downloadables_list.remove(self)

ValueError: list.remove(x): x not in list
```