### PR TITLE
Fixed incorrect Repeat.total_time_remaining. (#498)

### DIFF
--- a/addons/source-python/packages/source-python/listeners/tick.py
+++ b/addons/source-python/packages/source-python/listeners/tick.py
@@ -181,8 +181,7 @@ class Delay(WeakAutoUnload):
         :rtype: float
         """
         if not self.running:
-            # TODO: what should we return here, or should we raise an error?
-            return None
+            return 0
         return self.exec_time - time.time()
 
     @property
@@ -192,8 +191,7 @@ class Delay(WeakAutoUnload):
         :rtype: float
         """
         if not self.running:
-            # TODO: what should we return here, or should we raise an error?
-            return None
+            return 0
         return time.time() - self._start_time
 
     def _unload_instance(self):
@@ -314,7 +312,7 @@ class Repeat(AutoUnload):
 
         :rtype: float
         """
-        if self.delay_time_remaining is None:
+        if not self.delay_time_remaining:
             return 0
         return (
             (self.loops_remaining - 1) * self.interval +

--- a/addons/source-python/packages/source-python/listeners/tick.py
+++ b/addons/source-python/packages/source-python/listeners/tick.py
@@ -315,9 +315,9 @@ class Repeat(AutoUnload):
         :rtype: float
         """
         if self.delay_time_remaining is None:
-            return None
+            return 0
         return (
-            self.loops_remaining * self.interval +
+            (self.loops_remaining - 1) * self.interval +
             self.delay_time_remaining
         )
 


### PR DESCRIPTION
Fix for #498.

Changed Repeat.total_time_remaining to return 0 since there is no rational reason for it to return None when there is no delay or when Repeat is finished.