### PR TITLE
Fixes an error caused when the name of BaseEntityOutput is overlapped with another DataDesc.

### DIFF
--- a/src/core/modules/entities/entities_entity.cpp
+++ b/src/core/modules/entities/entities_entity.cpp
@@ -180,7 +180,7 @@ CBaseEntityOutputWrapper* CBaseEntityWrapper::get_output(const char* name)
 			if (pCurrentDataDesc.externalName && strcmp(name, pCurrentDataDesc.externalName) == 0)
 			{
 				if (!(pCurrentDataDesc.flags & FTYPEDESC_OUTPUT))
-					BOOST_RAISE_EXCEPTION(PyExc_TypeError, "'%s' is not a valid output.", name);
+					continue;
 
 				return (CBaseEntityOutputWrapper *)((unsigned long)this + TypeDescriptionExt::get_offset(pCurrentDataDesc));
 			}


### PR DESCRIPTION
This fixes a problem with func_bomb_target not able to get BombExplode, etc.