### PR TITLE
Added support for the new Enum changes in Python 3.12.

### DIFF
--- a/addons/source-python/packages/source-python/weapons/instance.py
+++ b/addons/source-python/packages/source-python/weapons/instance.py
@@ -190,7 +190,7 @@ class WeaponClass(object):
         if isinstance(value, int):
             try:
                 return weapon_constants(value)
-            except ValueError:
+            except (ValueError, TypeError):
                 pass
         elif isinstance(value, str):
             try:


### PR DESCRIPTION
In Python 3.12, there is a destructive change in the `Enum` class that now raises `TypeError` if a member is empty.

https://github.com/python/cpython/issues/108682
https://github.com/python/cpython/commit/d48760b2f1e28dd3c1a35721939f400a8ab619b8#diff-e5dd6e444e4e6c2cdeb8edf271d057f9da52f7b406dcd8b655dc396fb013bd03R1117-R1121

This may affect other parts of the SP code, but the currently causing the problem by `WeaponSlot` is fixed first.
Fix #516 issues.