### PR TITLE
Fixed the eye angle property for HL2DM.

### DIFF
--- a/src/core/modules/players/players_entity.h
+++ b/src/core/modules/players/players_entity.h
@@ -46,6 +46,8 @@ using namespace boost::python;
 	#define EYE_ANGLE_PROPERTY(index) "blackmesalocaldata.m_angEyeAngles[" #index "]"
 #elif defined(ENGINE_BRANCH_GMOD)
 	#define EYE_ANGLE_PROPERTY(index) "hl2mplocaldata.m_angEyeAngles[" #index "]"
+#elif defined(ENGINE_BRANCH_HL2DM)
+	#define EYE_ANGLE_PROPERTY(index) "hl2mpnonlocaldata.m_angEyeAngles[" #index "]"
 #else 
 	#define EYE_ANGLE_PROPERTY(index) "m_angEyeAngles[" #index "]"
 #endif


### PR DESCRIPTION
It appears they've changed the property for eye angles from **m_angEyeAngles** to **hl2mpnonlocaldata.m_angEyeAngles**.