### PR TITLE
Fixed missing import

### DIFF
--- a/addons/source-python/packages/source-python/weapons/engines/csgo/csgo.py
+++ b/addons/source-python/packages/source-python/weapons/engines/csgo/csgo.py
@@ -7,6 +7,7 @@
 # =============================================================================
 # Source.Python
 from . import Weapon as _Weapon
+from weapons.manager import weapon_manager
 #   Filters
 from filters.weapons import WeaponClassIter
 


### PR DESCRIPTION
Fixes NameError: name 'weapon_manager' is not defined for csgo
